### PR TITLE
[FIX] application.yaml 파일 환경 변수 주입 설정 수정

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,9 +6,9 @@ spring:
   application:
     name: DeviceService
 
-  # env 파일 내의 환경변수를 불러오는 설정
+  # env 파일 내의 환경변수를 불러오는 설정 (확장자가 없으므로 properties 형식으로 강제 파싱)
   config:
-    import: optional:file:.env
+    import: optional:file:.env[.properties]
 
   # 데이터베이스(MySQL) 연결 설정 (device_db)
   datasource:


### PR DESCRIPTION
## 📌 개요
#### 환경변수 주입 설정에서 확장자가 없어, .env 파일의 환경변수를 불러오지 못하는 문제 발견



## 🛠️ 작업 내용
* application.yaml 파일에 환경변수 주입시 .properties로 확장자 강제 파싱



## ✅ 체크리스트
- [X] 코드 컨벤션을 준수했나요?
- [X] 테스트를 완료했나요?
- [X] 불필요한 주석을 제거했나요?
