### PR TITLE
[FEAT] 제품 등록 API 구현 완료

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -5,8 +5,10 @@ DB_NAME=device_db
 DB_USERNAME=root
 DB_PASSWORD=your_db_secret_password
 
-# JWT Settings (Auth Service와 동일한 공유 비밀키 사용)
+# JWT Settings (Auth Service와 동일한 공유 비밀키 및 속성 사용)
 JWT_SECRET=your_super_secret_jwt_signature_key_for_auth_service
+JWT_ACCESS_EXPIRATION=3600000
+JWT_REFRESH_EXPIRATION=1209600000
 
 # MSA Internal Auth Header Secret (서비스 간 통신 보안 암호)
 INTERNAL_SECRET_KEY=your_msa_shared_internal_secret_key

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	// 기기 및 영수증 REST API 엔드포인트 구축을 위한 필수 웹 프레임워크
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	// JWT Bearer 토큰 검증 필터 및 SecurityFilterChain 구성을 위한 Spring Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	// 외부 API(네이버 쇼핑 등) 및 타 마이크로서비스 비동기 호출 클라이언트 (WebClient)
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	// API 명세서 포맷 자동 생성 및 Swagger UI 제공

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,8 @@ dependencies {
 
 	// 스프링 기본 통합 테스트 모듈 세트
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	// H2 인메모리 데이터베이스 (테스트 용도)
+	testImplementation 'com.h2database:h2'
 	// WebFlux(WebClient) 외부 API 호출 연관 비동기 통신 로직 테스트용
 	testImplementation 'io.projectreactor:reactor-test'
 	// JUnit5(Jupiter) 플랫폼 테스트 구동 엔진

--- a/src/main/java/com/After_Buy/DeviceService/config/InternalSecretFilter.java
+++ b/src/main/java/com/After_Buy/DeviceService/config/InternalSecretFilter.java
@@ -1,0 +1,69 @@
+package com.After_Buy.DeviceService.config;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * 인트라넷 내부망 통신 전용 커스텀 보안 필터
+ * 내부 MSA를 위해 /internal/** 경로로 들어오는 마이크로 서비스 간의 은밀한 호출을 타 외부인의 침입에 노출시키지 않도록 헤더 비밀키를 검수합니다.
+ *
+ * @since : 2026.04.06
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Slf4j
+@Component
+@Order(1)
+public class InternalSecretFilter implements Filter {
+
+	// 애플리케이션 환경설정에 지정된 관리자 전용 내부 통신 시크릿 키 평문
+	private final String internalSecretKey;
+
+	public InternalSecretFilter(@Value("${internal.secret-key}") String internalSecretKey) {
+		this.internalSecretKey = internalSecretKey;
+	}
+
+	/**
+	 * 커스텀 필터 코어 체이닝 로직
+	 * 서블릿의 URI가 internal로 시작할 경우 무조건 X-Internal-Secret 헤더의 무결성을 대조해본 뒤 통과시킵니다.
+	 *
+	 * @param req : 필터를 거쳐갈 1차 정제 전 날것의 서블릿 요청 객체
+	 * @param res : 처리 후 클라이언트 네트워크로 분출될 반환용 응답 객체
+	 * @param chain : 검문소를 지날 시 다음 컨트롤러나 필터로 향하게 해줄 허가 스프링 체인
+	 * @throws IOException : 네트워크 단선 등 I/O 문제 시 방출
+	 * @throws ServletException : 서블릿 컨테이너 내부 런타임 처리 도중 발생한 알 수 없는 침체 에러들 방어
+	 */
+	@Override
+	public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
+		HttpServletRequest request = (HttpServletRequest) req;
+		HttpServletResponse response = (HttpServletResponse) res;
+		String uri = request.getRequestURI();
+
+		if (!uri.startsWith("/internal/")) {
+			chain.doFilter(req, res);
+			return;
+		}
+
+		String secretHeader = request.getHeader("X-Internal-Secret");
+		if (secretHeader == null || !secretHeader.equals(this.internalSecretKey)) {
+			log.warn("내부 API 접근 차단: 유효하지 않은 X-Internal-Secret 헤더, URI={}", uri);
+			response.setStatus(403);
+			response.setContentType("application/json");
+			response.setCharacterEncoding("UTF-8");
+			response.getWriter().write("{\"success\":false,\"error\":{\"code\":\"FORBIDDEN\",\"message\":\"내부 API 접근 권한이 없습니다.\"}}");
+			return;
+		}
+		chain.doFilter(req, res);
+	}
+}

--- a/src/main/java/com/After_Buy/DeviceService/config/SecurityConfig.java
+++ b/src/main/java/com/After_Buy/DeviceService/config/SecurityConfig.java
@@ -1,0 +1,81 @@
+package com.After_Buy.DeviceService.config;
+
+import com.After_Buy.DeviceService.security.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+/**
+ * 스프링 시큐리티 및 인가 방화벽 코어 구성 파일
+ * JWT 검증 필터를 체인에 등록하고 CSRF 비활성화, Stateless 세션, CORS 정책을 설정합니다.
+ * Device Service 전용 공개 엔드포인트(Actuator, Swagger, 내부 API)를 허용합니다.
+ *
+ * @since : 2026.04.06
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+	/**
+	 * 통합 서블릿 통행 제어 및 권한 결정 빈
+	 * CSRF를 끄고 JWT 필터를 최앞단에 장착하며 공개 허용 엔드포인트 예외를 처리하고
+	 * 나머지 모든 요청에 대해 인증을 요구합니다.
+	 *
+	 * @param http : 방어 체인을 빌드할 스프링의 HttpSecurity 원시 세팅 도구
+	 * @return : 각종 예외 정책과 룰이 버무려진 보안 필터 체인 반환
+	 * @throws Exception : 초기화 중 보안 객체 구성 불발 시 예외 강제 보고
+	 */
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http
+			.csrf(AbstractHttpConfigurer::disable)
+			.cors(cors -> cors.configurationSource(corsConfigurationSource()))
+			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.authorizeHttpRequests(auth -> auth
+				// 헬스 체크 및 Swagger UI 공개
+				.requestMatchers("/actuator/health").permitAll()
+				.requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
+				// MSA 내부 서비스 간 통신 경로 공개 (별도 InternalSecretFilter로 보호)
+				.requestMatchers("/internal/**").permitAll()
+				// 나머지 모든 Device API는 JWT 인증 필수
+				.anyRequest().authenticated()
+			)
+			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+		return http.build();
+	}
+
+	/**
+	 * CORS 횡단 자원 공유 정책 빈
+	 * 모바일 앱(React Native) 및 웹 클라이언트 양방향 환경에서 차단 없이 접속 가능하도록 설정합니다.
+	 *
+	 * @return : 모든 출처 및 헤더가 수락되도록 구성된 개방형 CORS 소스 집합 빈
+	 */
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration config = new CorsConfiguration();
+		config.setAllowedOriginPatterns(List.of("*"));
+		config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+		config.setAllowedHeaders(List.of("*"));
+		config.setAllowCredentials(true);
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", config);
+		return source;
+	}
+}

--- a/src/main/java/com/After_Buy/DeviceService/config/SwaggerConfig.java
+++ b/src/main/java/com/After_Buy/DeviceService/config/SwaggerConfig.java
@@ -1,0 +1,46 @@
+package com.After_Buy.DeviceService.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Swagger(SpringDoc OpenAPI) 설정 파일
+ * Swagger UI에서 JWT Bearer Token 입력란을 제공하여 인증이 필요한 API를 테스트할 수 있도록 설정합니다.
+ *
+ * @since : 2026.04.06
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Configuration
+public class SwaggerConfig {
+
+	/**
+	 * OpenAPI 명세 빈 등록 메소드
+	 * Device Service API 정보 및 JWT Bearer Token 인증 스키마를 Swagger UI에 등록합니다.
+	 *
+	 * @return : JWT 인증이 설정된 OpenAPI 명세 빈
+	 */
+	@Bean
+	public OpenAPI openAPI() {
+		// JWT Bearer Token 인증 스키마 정의
+		String securitySchemeName = "BearerAuth";
+		SecurityScheme securityScheme = new SecurityScheme()
+				.type(SecurityScheme.Type.HTTP)
+				.scheme("bearer")
+				.bearerFormat("JWT")
+				.name(securitySchemeName);
+
+		return new OpenAPI()
+				.info(new Info()
+						.title("AfterBuy - Device Service API")
+						.description("기기 관리(CRUD), OCR, 네이버 쇼핑 검색, S3 이미지 업로드, 폴더 관리 API")
+						.version("v1.0.0"))
+				.addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+				.components(new Components().addSecuritySchemes(securitySchemeName, securityScheme));
+	}
+}

--- a/src/main/java/com/After_Buy/DeviceService/controller/DeviceController.java
+++ b/src/main/java/com/After_Buy/DeviceService/controller/DeviceController.java
@@ -1,0 +1,57 @@
+package com.After_Buy.DeviceService.controller;
+
+import com.After_Buy.DeviceService.dto.request.DeviceRegisterRequest;
+import com.After_Buy.DeviceService.dto.response.ApiResponse;
+import com.After_Buy.DeviceService.dto.response.DeviceResponse;
+import com.After_Buy.DeviceService.security.UserPrincipal;
+import com.After_Buy.DeviceService.service.DeviceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 기기 CRUD 컨트롤러
+ * 기기 등록, 조회, 수정, 삭제 API 엔드포인트를 제공합니다.
+ * Base URL: /api/devices
+ * 포트: 8082
+ * 모든 엔드포인트는 JWT Bearer 토큰 인증 필수입니다.
+ *
+ * @since : 2026.04.06
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/devices")
+@RequiredArgsConstructor
+@Tag(name = "Devices", description = "기기 CRUD API")
+public class DeviceController {
+
+	private final DeviceService deviceService;
+
+	/**
+	 * 기기 등록 API
+	 * 새 기기를 등록합니다. warranty_expiry_date는 서버에서 purchase_date + warranty_months로 자동 계산 후 저장합니다.
+	 * image_url이 없을 경우 placeholder 이미지가 자동으로 삽입됩니다.
+	 *
+	 * @param userPrincipal : JWT 토큰에서 추출된 인증 사용자 정보
+	 * @param request       : 기기 등록 요청 DTO (@Valid 유효성 검사 적용)
+	 * @return : 201 Created + 등록된 기기 전체 정보
+	 * @throws com.After_Buy.DeviceService.exception.CustomException : folder_id 검증 실패 시 DEVICE-001 (404)
+	 */
+	@Operation(summary = "기기 등록", description = "새 기기를 등록합니다. warranty_expiry_date는 서버에서 자동 계산됩니다.")
+	@PostMapping
+	public ResponseEntity<ApiResponse<DeviceResponse>> registerDevice(
+			@AuthenticationPrincipal UserPrincipal userPrincipal,
+			@Valid @RequestBody DeviceRegisterRequest request) {
+		log.info("기기 등록 요청: userId={}", userPrincipal.getUserId());
+		DeviceResponse response = deviceService.registerDevice(userPrincipal.getUserId(), request);
+		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+	}
+}

--- a/src/main/java/com/After_Buy/DeviceService/dto/request/DeviceRegisterRequest.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/request/DeviceRegisterRequest.java
@@ -1,0 +1,92 @@
+package com.After_Buy.DeviceService.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * 기기 등록 요청 DTO
+ * POST /api/devices 요청 바디를 매핑합니다.
+ * API 명세서 기준 필수 항목(@NotBlank, @NotNull)과 선택 항목(nullable)을 구분합니다.
+ *
+ * 필수 항목 (빨간별 *): product_name, model_name, brand, purchase_date, purchase_price, warranty_months
+ * 선택 항목             : folder_id, image_url, product_link_url, purchase_store, serial_number, memo
+ *
+ * @since : 2026.04.06
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@NoArgsConstructor
+public class DeviceRegisterRequest {
+
+	/* ===== 선택 항목 ===== */
+
+	// 소속 폴더 ID (null = 미분류 상태로 저장, 미입력 시 최상위 레벨에 노출)
+	@Schema(description = "소속 폴더 ID (미입력 시 미분류 상태로 저장)", nullable = true, example = "null")
+	private Long folderId;
+
+	/* ===== 필수 항목 ===== */
+
+	// 상품명 (필수, 최대 200자)
+	@NotBlank(message = "상품명은 필수 입력값입니다.")
+	@Size(max = 200, message = "상품명은 200자 이내여야 합니다.")
+	private String productName;
+
+	// 모델명 (필수, 최대 100자)
+	@NotBlank(message = "모델명은 필수 입력값입니다.")
+	@Size(max = 100, message = "모델명은 100자 이내여야 합니다.")
+	private String modelName;
+
+	// 브랜드명 (필수, 최대 100자)
+	@NotBlank(message = "브랜드명은 필수 입력값입니다.")
+	@Size(max = 100, message = "브랜드명은 100자 이내여야 합니다.")
+	private String brand;
+
+	/* ===== 선택 항목 ===== */
+
+	// 기기 이미지 URL (선택, S3 Pre-signed URL 업로드 후 전달, 없으면 placeholder 자동 삽입)
+	@Size(max = 500, message = "이미지 URL은 500자 이내여야 합니다.")
+	private String imageUrl;
+
+	// 공식 제품 페이지 URL (선택, 네이버 쇼핑 API 연동)
+	@Size(max = 500, message = "제품 링크 URL은 500자 이내여야 합니다.")
+	private String productLinkUrl;
+
+	/* ===== 필수 항목 ===== */
+
+	// 구매일 (필수, YYYY-MM-DD 형식, 영수증 OCR 또는 직접 입력)
+	@NotNull(message = "구매일은 필수 입력값입니다.")
+	private LocalDate purchaseDate;
+
+	// 구매 가격 (필수, DECIMAL(12,2), 영수증 OCR 또는 직접 입력)
+	@NotNull(message = "구매 가격은 필수 입력값입니다.")
+	@DecimalMin(value = "0.0", inclusive = false, message = "구매 가격은 0보다 커야 합니다.")
+	private BigDecimal purchasePrice;
+
+	/* ===== 선택 항목 ===== */
+
+	// 구매처 (선택, 영수증 OCR 또는 직접 입력, 최대 100자)
+	@Size(max = 100, message = "구매처는 100자 이내여야 합니다.")
+	private String purchaseStore;
+
+	/* ===== 필수 항목 ===== */
+
+	// 무상 보증 기간 개월 수 (필수, INT UNSIGNED)
+	@NotNull(message = "무상 보증 기간은 필수 입력값입니다.")
+	@Min(value = 1, message = "무상 보증 기간은 1개월 이상이어야 합니다.")
+	private Integer warrantyMonths;
+
+	/* ===== 선택 항목 ===== */
+
+	// 시리얼 넘버 (선택, OCR 또는 직접 입력, 최대 100자)
+	@Size(max = 100, message = "시리얼 넘버는 100자 이내여야 합니다.")
+	private String serialNumber;
+
+	// 사용자 메모 (선택)
+	private String memo;
+}

--- a/src/main/java/com/After_Buy/DeviceService/dto/response/ApiResponse.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/response/ApiResponse.java
@@ -1,0 +1,53 @@
+package com.After_Buy.DeviceService.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+/**
+ * 공통 API 성공 응답 DTO
+ * Device Service의 성공 응답을 {"success": true, "data": {...}} 형식으로 통일하는 래퍼 클래스입니다.
+ * 에러 응답은 ErrorResponse 클래스를 사용합니다.
+ *
+ * @since : 2026.04.06
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+
+	// 요청 성공 여부
+	private final boolean success;
+
+	// 응답 데이터 제네릭 (성공 시 존재, 실패 시 null)
+	private final T data;
+
+	// 성공 메시지 (데이터 없는 단순 성공 응답 시 사용)
+	private final String message;
+
+	private ApiResponse(boolean success, T data, String message) {
+		this.success = success;
+		this.data = data;
+		this.message = message;
+	}
+
+	/**
+	 * 성공 응답 생성 (데이터만 존재)
+	 *
+	 * @param data : 응답 데이터
+	 * @return : success=true, data=data 인 ApiResponse
+	 */
+	public static <T> ApiResponse<T> success(T data) {
+		return new ApiResponse<>(true, data, null);
+	}
+
+	/**
+	 * 성공 응답 생성 (메시지만 존재, 단순 성공 알림용)
+	 *
+	 * @param message : 성공 알림 메시지
+	 * @return : success=true, message=message 인 ApiResponse
+	 */
+	public static ApiResponse<Void> successMessage(String message) {
+		return new ApiResponse<>(true, null, message);
+	}
+}

--- a/src/main/java/com/After_Buy/DeviceService/dto/response/DeviceResponse.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/response/DeviceResponse.java
@@ -1,0 +1,105 @@
+package com.After_Buy.DeviceService.dto.response;
+
+import com.After_Buy.DeviceService.entity.Device;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 기기 응답 DTO
+ * POST /api/devices 성공(201 Created) 응답 및 GET /api/devices/{device_id} 응답에 사용됩니다.
+ * API 명세서의 201 Created 응답 구조와 동일합니다.
+ *
+ * @since : 2026.04.06
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DeviceResponse {
+
+	// 기기 고유 ID
+	private final Long deviceId;
+
+	// 소유 사용자 ID
+	private final Long userId;
+
+	// 소속 폴더 ID (null = 미분류)
+	private final Long folderId;
+
+	// 상품명
+	private final String productName;
+
+	// 모델명
+	private final String modelName;
+
+	// 브랜드명
+	private final String brand;
+
+	// 기기 이미지 URL (null 시 placeholder 이미지 적용됨)
+	private final String imageUrl;
+
+	// 공식 제품 페이지 URL
+	private final String productLinkUrl;
+
+	// 구매일
+	private final LocalDate purchaseDate;
+
+	// 구매 가격
+	private final BigDecimal purchasePrice;
+
+	// 구매처
+	private final String purchaseStore;
+
+	// 무상 보증 기간 개월 수
+	private final Integer warrantyMonths;
+
+	// 보증 만료일 (purchase_date + warranty_months 자동 계산)
+	private final LocalDate warrantyExpiryDate;
+
+	// 시리얼 넘버
+	private final String serialNumber;
+
+	// 사용자 메모
+	private final String memo;
+
+	// 등록 일시
+	private final LocalDateTime createdAt;
+
+	// 마지막 수정 일시
+	private final LocalDateTime updatedAt;
+
+	/**
+	 * Device 엔티티로부터 응답 DTO를 생성하는 정적 팩토리 메소드
+	 * Entity → DTO 변환을 일관되게 처리합니다.
+	 *
+	 * @param device : 변환할 Device 엔티티
+	 * @return : 클라이언트에 반환할 DeviceResponse DTO
+	 */
+	public static DeviceResponse from(Device device) {
+		return new DeviceResponse(device);
+	}
+
+	private DeviceResponse(Device device) {
+		this.deviceId = device.getDeviceId();
+		this.userId = device.getUserId();
+		this.folderId = device.getFolderId();
+		this.productName = device.getProductName();
+		this.modelName = device.getModelName();
+		this.brand = device.getBrand();
+		this.imageUrl = device.getImageUrl();
+		this.productLinkUrl = device.getProductLinkUrl();
+		this.purchaseDate = device.getPurchaseDate();
+		this.purchasePrice = device.getPurchasePrice();
+		this.purchaseStore = device.getPurchaseStore();
+		this.warrantyMonths = device.getWarrantyMonths();
+		this.warrantyExpiryDate = device.getWarrantyExpiryDate();
+		this.serialNumber = device.getSerialNumber();
+		this.memo = device.getMemo();
+		this.createdAt = device.getCreatedAt();
+		this.updatedAt = device.getUpdatedAt();
+	}
+}

--- a/src/main/java/com/After_Buy/DeviceService/entity/Device.java
+++ b/src/main/java/com/After_Buy/DeviceService/entity/Device.java
@@ -1,0 +1,145 @@
+package com.After_Buy.DeviceService.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 기기 엔티티
+ * 사용자가 등록한 전자기기의 모든 정보를 관리하는 JPA 엔티티입니다.
+ * 네이버 쇼핑 API·OCR·사용자 직접 입력 데이터를 저장하며,
+ * folder_id = NULL은 미분류 상태를 의미합니다.
+ * DB: device_db.devices
+ *
+ * @since : 2026.04.06
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "devices")
+public class Device {
+
+	// 기기 고유 ID (AUTO_INCREMENT)
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "device_id")
+	private Long deviceId;
+
+	// 소유 사용자 ID (auth_db.users 논리 참조)
+	@Column(name = "user_id", nullable = false)
+	private Long userId;
+
+	// 소속 폴더 ID (NULL = 미분류, folders.folder_id FK)
+	@Column(name = "folder_id")
+	private Long folderId;
+
+	// 상품명 (필수, 최대 200자)
+	@Column(name = "product_name", nullable = false, length = 200)
+	private String productName;
+
+	// 모델명 (필수, 최대 100자, OCR 또는 직접 입력)
+	@Column(name = "model_name", nullable = false, length = 100)
+	private String modelName;
+
+	// 브랜드명 (필수, 최대 100자)
+	@Column(name = "brand", nullable = false, length = 100)
+	private String brand;
+
+	// 기기 이미지 S3 URL (선택, 최대 500자)
+	@Column(name = "image_url", length = 500)
+	private String imageUrl;
+
+	// 공식 제품 페이지 URL (선택, 네이버 쇼핑 API 연동, 최대 500자)
+	@Column(name = "product_link_url", length = 500)
+	private String productLinkUrl;
+
+	// 구매일 (필수, 영수증 OCR 또는 직접 입력)
+	@Column(name = "purchase_date", nullable = false)
+	private LocalDate purchaseDate;
+
+	// 구매 가격 (필수, 최대 DECIMAL(12,2))
+	@Column(name = "purchase_price", nullable = false, precision = 12, scale = 2)
+	private BigDecimal purchasePrice;
+
+	// 구매처 (선택, 최대 100자)
+	@Column(name = "purchase_store", length = 100)
+	private String purchaseStore;
+
+	// 무상 보증 기간 개월 수 (필수, INT UNSIGNED)
+	@Column(name = "warranty_months", nullable = false)
+	private Integer warrantyMonths;
+
+	/*
+	 * 보증 만료일 (필수, purchase_date + warranty_months 자동 계산 후 저장)
+	 * 서버에서 자동 계산하므로 클라이언트로부터 받지 않습니다.
+	 */
+	@Column(name = "warranty_expiry_date", nullable = false)
+	private LocalDate warrantyExpiryDate;
+
+	// 시리얼 넘버 (선택, S/N, OCR 또는 직접 입력, 최대 100자)
+	@Column(name = "serial_number", length = 100)
+	private String serialNumber;
+
+	// 사용자 메모 (선택, TEXT)
+	@Column(name = "memo", columnDefinition = "TEXT")
+	private String memo;
+
+	// 등록 일시 (자동 설정)
+	@CreationTimestamp
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	// 마지막 수정 일시 (자동 업데이트)
+	@UpdateTimestamp
+	@Column(name = "updated_at", nullable = false)
+	private LocalDateTime updatedAt;
+
+	/**
+	 * 기기 등록 Builder 생성자
+	 * Service 계층에서 등록 시 사용하며, warrantyExpiryDate는 Service에서 자동 계산하여 주입합니다.
+	 *
+	 * @param userId              : 소유 사용자 ID
+	 * @param folderId            : 소속 폴더 ID (null = 미분류)
+	 * @param productName         : 상품명
+	 * @param modelName           : 모델명
+	 * @param brand               : 브랜드명
+	 * @param imageUrl            : 이미지 URL
+	 * @param productLinkUrl      : 제품 링크 URL
+	 * @param purchaseDate        : 구매일
+	 * @param purchasePrice       : 구매 가격
+	 * @param purchaseStore       : 구매처
+	 * @param warrantyMonths      : 보증 기간(개월)
+	 * @param warrantyExpiryDate  : 보증 만료일 (자동 계산)
+	 * @param serialNumber        : 시리얼 넘버
+	 * @param memo                : 메모
+	 */
+	@Builder
+	public Device(Long userId, Long folderId, String productName, String modelName, String brand,
+			String imageUrl, String productLinkUrl, LocalDate purchaseDate, BigDecimal purchasePrice,
+			String purchaseStore, Integer warrantyMonths, LocalDate warrantyExpiryDate,
+			String serialNumber, String memo) {
+		this.userId = userId;
+		this.folderId = folderId;
+		this.productName = productName;
+		this.modelName = modelName;
+		this.brand = brand;
+		this.imageUrl = imageUrl;
+		this.productLinkUrl = productLinkUrl;
+		this.purchaseDate = purchaseDate;
+		this.purchasePrice = purchasePrice;
+		this.purchaseStore = purchaseStore;
+		this.warrantyMonths = warrantyMonths;
+		this.warrantyExpiryDate = warrantyExpiryDate;
+		this.serialNumber = serialNumber;
+		this.memo = memo;
+	}
+}

--- a/src/main/java/com/After_Buy/DeviceService/entity/Folder.java
+++ b/src/main/java/com/After_Buy/DeviceService/entity/Folder.java
@@ -1,0 +1,54 @@
+package com.After_Buy.DeviceService.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * 폴더 엔티티
+ * 사용자가 기기를 분류하기 위해 만드는 폴더를 관리하는 JPA 엔티티입니다.
+ * parent_folder_id 자기참조 구조로 계층형 폴더 구조를 구현합니다.
+ * DB: device_db.folders
+ *
+ * @since : 2026.04.06
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "folders")
+public class Folder {
+
+	// 폴더 고유 ID (AUTO_INCREMENT)
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "folder_id")
+	private Long folderId;
+
+	// 폴더 소유 사용자 ID (auth_db.users 논리 참조)
+	@Column(name = "user_id", nullable = false)
+	private Long userId;
+
+	// 상위 폴더 ID (NULL = 루트 폴더)
+	@Column(name = "parent_folder_id")
+	private Long parentFolderId;
+
+	// 폴더명 (최대 100자)
+	@Column(name = "folder_name", nullable = false, length = 100)
+	private String folderName;
+
+	// 생성 일시 (자동 설정)
+	@CreationTimestamp
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	// 마지막 수정 일시 (자동 업데이트)
+	@UpdateTimestamp
+	@Column(name = "updated_at", nullable = false)
+	private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/After_Buy/DeviceService/exception/CustomException.java
+++ b/src/main/java/com/After_Buy/DeviceService/exception/CustomException.java
@@ -1,0 +1,27 @@
+package com.After_Buy.DeviceService.exception;
+
+import lombok.Getter;
+
+/**
+ * 마이크로 서비스 도메인 정책 전용 예외 클래스
+ * 비즈니스 로직에서 의도적으로 발생시키는 예외입니다.
+ * ErrorCode Enum을 담아 GlobalExceptionHandler에서 표준 에러 응답으로 변환합니다.
+ * AdminService의 CustomException.java와 동일한 패턴을 사용합니다.
+ *
+ * 사용 예시: throw new CustomException(ErrorCode.DEVICE_FOLDER_NOT_FOUND);
+ *
+ * @since : 2026.04.06
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+public class CustomException extends RuntimeException {
+
+	/** 에러 상태 코드, 커스텀 코드, 메시지를 담은 Enum */
+	private final ErrorCode errorCode;
+
+	public CustomException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+}

--- a/src/main/java/com/After_Buy/DeviceService/exception/ErrorCode.java
+++ b/src/main/java/com/After_Buy/DeviceService/exception/ErrorCode.java
@@ -1,0 +1,52 @@
+package com.After_Buy.DeviceService.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 서비스 전역 에러 코드 Enum
+ * 에러 발생 시 클라이언트에게 내려줄 HTTP 상태 코드, 커스텀 코드, 메시지를 관리합니다.
+ * AdminService의 ErrorCode.java와 동일한 패턴을 사용합니다.
+ *
+ * @since : 2026.04.06
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+	/* ===== 기기 관련 (DEVICE-0XX) ===== */
+
+	/** 폴더가 존재하지 않거나 본인 소유가 아닌 경우 */
+	DEVICE_FOLDER_NOT_FOUND(HttpStatus.NOT_FOUND, "DEVICE-001", "존재하지 않거나 접근 권한이 없는 폴더입니다."),
+
+	/** 기기가 존재하지 않거나 본인 소유가 아닌 경우 */
+	DEVICE_NOT_FOUND(HttpStatus.NOT_FOUND, "DEVICE-002", "존재하지 않거나 접근 권한이 없는 기기입니다."),
+
+	/* ===== OCR 관련 (OCR-0XX) ===== */
+
+	/** OCR 텍스트 인식 실패 */
+	OCR_RECOGNITION_FAILED(HttpStatus.UNPROCESSABLE_ENTITY, "OCR-001", "이미지에서 텍스트를 인식하지 못했습니다."),
+
+	/* ===== 공통 (COMMON-0XX) ===== */
+
+	/** @Valid 유효성 검사 실패 */
+	INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "COMMON-001", "입력값이 올바르지 않습니다."),
+
+	/** 인증 실패 (JWT 토큰 없음 또는 만료) */
+	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON-401", "인증이 필요합니다."),
+
+	/** 서버 내부 오류 */
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON-500", "서버 내부 오류가 발생했습니다.");
+
+	/** HTTP 상태 코드 */
+	private final HttpStatus httpStatus;
+
+	/** 프론트엔드 분기용 커스텀 에러 코드 */
+	private final String code;
+
+	/** 클라이언트에게 전달할 에러 메시지 */
+	private final String message;
+}

--- a/src/main/java/com/After_Buy/DeviceService/exception/ErrorResponse.java
+++ b/src/main/java/com/After_Buy/DeviceService/exception/ErrorResponse.java
@@ -1,0 +1,98 @@
+package com.After_Buy.DeviceService.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 공통 에러 응답 DTO
+ * API 명세서(예외 처리 방법.md)에서 정의한 표준 에러 응답 JSON 형식을 구현합니다.
+ * 성공 응답은 ApiResponse로 처리하고, 에러 응답은 이 클래스를 사용합니다.
+ *
+ * @since : 2026.04.06
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ErrorResponse {
+
+	// 에러 발생 서버 시각
+	private final String timestamp;
+
+	// HTTP 상태 코드 (400, 401, 403, 404, 500 등)
+	private final int status;
+
+	// 팀 내 약속된 비즈니스 예외 코드 (예: DEVICE-001, COMMON-001)
+	private final String code;
+
+	// 클라이언트에게 전달할 한글 에러 안내 메시지
+	private final String message;
+
+	// @Valid 유효성 검사 실패 시 필드별 에러 상세 정보 (일반 비즈니스 에러 시 빈 배열)
+	private final List<FieldError> errors;
+
+	// 에러가 발생한 API 엔드포인트 경로
+	private final String path;
+
+	private ErrorResponse(int status, String code, String message, List<FieldError> errors, String path) {
+		this.timestamp = LocalDateTime.now().toString();
+		this.status = status;
+		this.code = code;
+		this.message = message;
+		this.errors = errors;
+		this.path = path;
+	}
+
+	/**
+	 * 비즈니스 예외(CustomException) 발생 시 에러 응답 생성
+	 * errors 필드는 빈 배열로 반환합니다.
+	 *
+	 * @param status  : HTTP 상태 코드
+	 * @param code    : 비즈니스 예외 코드
+	 * @param message : 에러 메시지
+	 * @param path    : 요청 경로
+	 * @return : 표준 에러 응답 객체
+	 */
+	public static ErrorResponse of(int status, String code, String message, String path) {
+		return new ErrorResponse(status, code, message, List.of(), path);
+	}
+
+	/**
+	 * @Valid 유효성 검사 실패 시 에러 응답 생성
+	 * errors 필드에 필드별 상세 에러 정보를 담습니다.
+	 *
+	 * @param status  : HTTP 상태 코드
+	 * @param code    : 비즈니스 예외 코드
+	 * @param message : 에러 메시지
+	 * @param errors  : 필드별 에러 상세 정보 목록
+	 * @param path    : 요청 경로
+	 * @return : 필드 에러가 포함된 표준 에러 응답 객체
+	 */
+	public static ErrorResponse of(int status, String code, String message, List<FieldError> errors, String path) {
+		return new ErrorResponse(status, code, message, errors, path);
+	}
+
+	/**
+	 * @Valid 유효성 검사 실패 필드별 에러 상세 정보 이너 클래스
+	 */
+	@Getter
+	public static class FieldError {
+		// 유효성 검사에 실패한 필드명
+		private final String field;
+
+		// 실패한 필드에 입력된 실제 값
+		private final String value;
+
+		// 실패 사유 메시지
+		private final String reason;
+
+		public FieldError(String field, String value, String reason) {
+			this.field = field;
+			this.value = value;
+			this.reason = reason;
+		}
+	}
+}

--- a/src/main/java/com/After_Buy/DeviceService/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/After_Buy/DeviceService/exception/GlobalExceptionHandler.java
@@ -1,0 +1,105 @@
+package com.After_Buy.DeviceService.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * AOP 기반 스프링 최상위 통합 시스템 오류 관제 매니저
+ * 컨트롤러와 서비스 전역에서 발생하는 예외를 흡수하고
+ * API 명세서(예외 처리 방법.md)에 정의된 표준 ErrorResponse 포맷으로 변환해 반환합니다.
+ * AdminService의 GlobalExceptionHandler와 동일한 패턴을 사용합니다.
+ *
+ * @since : 2026.04.06
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	/**
+	 * 커스텀 도메인 특화 비즈니스 예외 핸들링
+	 * Service에서 throw new CustomException(ErrorCode.XXX)으로 발생시킨 예외를 처리합니다.
+	 *
+	 * @param e       발생한 CustomException
+	 * @param request 현재 HTTP 요청 (path 추출용)
+	 * @return 표준 에러 응답 JSON
+	 */
+	@ExceptionHandler(CustomException.class)
+	public ResponseEntity<ErrorResponse> handleCustomException(CustomException e, HttpServletRequest request) {
+		ErrorCode errorCode = e.getErrorCode();
+		log.warn("[CustomException] code={}, message={}, path={}",
+				errorCode.getCode(), errorCode.getMessage(), request.getRequestURI());
+
+		ErrorResponse errorResponse = ErrorResponse.of(
+				errorCode.getHttpStatus().value(),
+				errorCode.getCode(),
+				errorCode.getMessage(),
+				request.getRequestURI()
+		);
+		return ResponseEntity.status(errorCode.getHttpStatus()).body(errorResponse);
+	}
+
+	/**
+	 * @Valid 유효성 검사 실패 핸들링
+	 * DTO 어노테이션 기반 파라미터 검증 실패 시 각 필드의 field, value, reason을 errors 배열에 담아 반환합니다.
+	 *
+	 * @param e       @Valid 유효성 검사 실패 시 스프링이 발생시키는 예외 객체
+	 * @param request 현재 HTTP 요청 (path 추출용)
+	 * @return 필드별 유효성 에러가 포함된 400 BAD REQUEST 표준 ErrorResponse
+	 */
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e,
+			HttpServletRequest request) {
+		BindingResult bindingResult = e.getBindingResult();
+
+		/* 모든 필드 에러를 순회하여 field, value, reason을 추출 후 FieldError 목록으로 변환 */
+		List<ErrorResponse.FieldError> fieldErrors = bindingResult.getFieldErrors().stream()
+				.map(fe -> new ErrorResponse.FieldError(
+						fe.getField(),
+						fe.getRejectedValue() != null ? fe.getRejectedValue().toString() : "",
+						fe.getDefaultMessage()
+				))
+				.collect(Collectors.toList());
+
+		log.warn("[ValidationException] path={}, errors={}", request.getRequestURI(), fieldErrors);
+
+		ErrorResponse errorResponse = ErrorResponse.of(
+				ErrorCode.INVALID_INPUT_VALUE.getHttpStatus().value(),
+				ErrorCode.INVALID_INPUT_VALUE.getCode(),
+				ErrorCode.INVALID_INPUT_VALUE.getMessage(),
+				fieldErrors,
+				request.getRequestURI()
+		);
+		return ResponseEntity.badRequest().body(errorResponse);
+	}
+
+	/**
+	 * 알 수 없는 서버 내부 예외 핸들링 (최종 디펜스 라인)
+	 * 예상치 못한 500급 예외를 처리합니다. 내부 구조 노출을 막고 500 응답으로 변환합니다.
+	 *
+	 * @param e       컨트롤러 통제 밖까지 도달한 예외
+	 * @param request 현재 HTTP 요청 (path 추출용)
+	 * @return 500 INTERNAL SERVER ERROR 응답
+	 */
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ErrorResponse> handleException(Exception e, HttpServletRequest request) {
+		log.error("[UnhandledException] path={}, message={}", request.getRequestURI(), e.getMessage(), e);
+
+		ErrorResponse errorResponse = ErrorResponse.of(
+				ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus().value(),
+				ErrorCode.INTERNAL_SERVER_ERROR.getCode(),
+				ErrorCode.INTERNAL_SERVER_ERROR.getMessage(),
+				request.getRequestURI()
+		);
+		return ResponseEntity.internalServerError().body(errorResponse);
+	}
+}

--- a/src/main/java/com/After_Buy/DeviceService/repository/DeviceRepository.java
+++ b/src/main/java/com/After_Buy/DeviceService/repository/DeviceRepository.java
@@ -1,0 +1,16 @@
+package com.After_Buy.DeviceService.repository;
+
+import com.After_Buy.DeviceService.entity.Device;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * 기기 레포지토리
+ * devices 테이블에 대한 JPA 데이터 액세스 레이어입니다.
+ * 기기 CRUD 전반에 걸쳐 사용되며, 현재는 기기 등록(save)을 위한 기본 메서드를 제공합니다.
+ *
+ * @since : 2026.04.06
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+public interface DeviceRepository extends JpaRepository<Device, Long> {
+}

--- a/src/main/java/com/After_Buy/DeviceService/repository/FolderRepository.java
+++ b/src/main/java/com/After_Buy/DeviceService/repository/FolderRepository.java
@@ -1,0 +1,29 @@
+package com.After_Buy.DeviceService.repository;
+
+import com.After_Buy.DeviceService.entity.Folder;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * 폴더 레포지토리
+ * folders 테이블에 대한 JPA 데이터 액세스 레이어입니다.
+ * 기기 등록 시 folder_id 유효성 및 소유권 검증에 사용됩니다.
+ *
+ * @since : 2026.04.06
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+public interface FolderRepository extends JpaRepository<Folder, Long> {
+
+	/**
+	 * 폴더 ID와 사용자 ID로 폴더 조회
+	 * 기기 등록 시 folder_id가 존재하는지, 그리고 현재 사용자 소유인지를 동시에 검증합니다.
+	 * (API 명세서: "folder_id가 존재하지 않거나 본인 폴더가 아닌 경우 → DEVICE-001, 404")
+	 *
+	 * @param folderId : 검증할 폴더의 고유 ID
+	 * @param userId   : 현재 인증된 사용자 ID
+	 * @return : 조건에 맞는 폴더 Optional (없으면 empty)
+	 */
+	Optional<Folder> findByFolderIdAndUserId(Long folderId, Long userId);
+}

--- a/src/main/java/com/After_Buy/DeviceService/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/After_Buy/DeviceService/security/JwtAuthenticationFilter.java
@@ -1,0 +1,79 @@
+package com.After_Buy.DeviceService.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * JWT 토큰 검증 필터
+ * 스프링 시큐리티 인증 필터 체인 앞단에서 매 요청마다 Authorization 헤더의 Bearer 토큰을 파싱하고,
+ * 유효한 경우 SecurityContextHolder에 UserPrincipal 인증 객체를 등록합니다.
+ *
+ * @since : 2026.04.06
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private final JwtTokenProvider jwtTokenProvider;
+
+	/**
+	 * 필터 체인 내부 검증 로직 구현부
+	 * 서블릿 컨테이너로 들어오는 모든 요청에 대해 Authorization 헤더를 확인하고,
+	 * 정상 토큰일 시 UserPrincipal을 시큐리티 컨텍스트에 주입합니다.
+	 *
+	 * @param request     : 클라이언트가 보낸 HTTP 서블릿 리퀘스트
+	 * @param response    : 클라이언트에게 보낼 HTTP 서블릿 리스폰스
+	 * @param filterChain : 뒤에 이어질 보안 및 컨트롤러 체인 라인
+	 * @throws ServletException : 서블릿 단 예외 발생 시
+	 * @throws IOException      : I/O 네트워크 파이프 단절 시 발생
+	 */
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+			throws ServletException, IOException {
+		String token = extractToken(request);
+		if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+			try {
+				Long userId = jwtTokenProvider.getUserIdFromToken(token);
+				UserPrincipal userPrincipal = new UserPrincipal(userId);
+				UsernamePasswordAuthenticationToken authentication =
+						new UsernamePasswordAuthenticationToken(userPrincipal, null, List.of());
+				authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+				SecurityContextHolder.getContext().setAuthentication(authentication);
+			} catch (Exception e) {
+				log.debug("JWT 인증 처리 중 오류: {}", e.getMessage());
+			}
+		}
+		filterChain.doFilter(request, response);
+	}
+
+	/**
+	 * Authorization 헤더 내 순수 토큰 정제 추출 헬퍼
+	 * Bearer 타입 규격의 토큰 문자열에서 프리픽스(Bearer )를 잘라내고 JWT 본체만 반환합니다.
+	 *
+	 * @param request : 토큰 헤더가 심겨있는 클라이언트의 요청 본문
+	 * @return : 정제된 JWT 서명 텍스트 (규격 불일치 또는 미존재 시 null 반환)
+	 */
+	private String extractToken(HttpServletRequest request) {
+		String bearerToken = request.getHeader("Authorization");
+		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+			return bearerToken.substring(7);
+		}
+		return null;
+	}
+}

--- a/src/main/java/com/After_Buy/DeviceService/security/JwtTokenProvider.java
+++ b/src/main/java/com/After_Buy/DeviceService/security/JwtTokenProvider.java
@@ -1,0 +1,83 @@
+package com.After_Buy.DeviceService.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * JWT 토큰 검증 전용 프로바이더
+ * Auth Service와 동일한 비밀키(JWT_SECRET)를 공유하여 이미 발급된 토큰의 서명 무결성을 검증하고
+ * 페이로드에서 user_id를 추출하는 역할만 수행합니다. (토큰 발급은 Auth Service 전담)
+ *
+ * @since : 2026.04.06
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+	private final SecretKey secretKey;
+	private final long accessExpiration;
+	private final long refreshExpiration;
+
+	public JwtTokenProvider(
+			@Value("${jwt.secret}") String secret,
+			@Value("${jwt.access-expiration}") long accessExpiration,
+			@Value("${jwt.refresh-expiration}") long refreshExpiration) {
+		this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+		this.accessExpiration = accessExpiration;
+		this.refreshExpiration = refreshExpiration;
+	}
+
+	/**
+	 * 정상 토큰 코어 데이터 복호화 디코드 처리
+	 * 검증 필터를 지난 외부 문자열 토큰의 서명 락을 풀어 주입되어있는 원래의 유저 ID 식별값을 강제로 추출해냅니다.
+	 *
+	 * @param token : 파싱을 시도할 암호 문자 원본
+	 * @return : 내재되어있던 유저의 데이터베이스 연동 PK 수동 반환
+	 */
+	public Long getUserIdFromToken(String token) {
+		Claims claims = parseClaims(token);
+		return Long.parseLong(claims.getSubject());
+	}
+
+	/**
+	 * 서명 및 형식 무결성 점검 보안 판독 기능
+	 * 위조·변조되거나 기간이 지난 토큰을 잡아내어 불량 처리하기 위한 부울린 반환형 탐지기 역할을 수행합니다.
+	 *
+	 * @param token : 클레임 파싱 무결성 점검을 시도할 암호 문자
+	 * @return : 정상적인 수명의 조작 없는 깨끗한 토큰일 시 true, 불량품이거나 만료 시 false 리턴
+	 */
+	public boolean validateToken(String token) {
+		try {
+			parseClaims(token);
+			return true;
+		} catch (ExpiredJwtException e) {
+			log.debug("만료된 JWT 토큰입니다: {}", e.getMessage());
+		} catch (JwtException | IllegalArgumentException e) {
+			log.debug("유효하지 않은 JWT 토큰입니다: {}", e.getMessage());
+		}
+		return false;
+	}
+
+	private Claims parseClaims(String token) {
+		return Jwts.parser().verifyWith(this.secretKey).build().parseSignedClaims(token).getPayload();
+	}
+
+	public java.util.Date getRefreshTokenExpiry() {
+		return new java.util.Date(System.currentTimeMillis() + this.refreshExpiration);
+	}
+
+	public java.util.Date getExpirationFromToken(String token) {
+		return parseClaims(token).getExpiration();
+	}
+}

--- a/src/main/java/com/After_Buy/DeviceService/security/UserPrincipal.java
+++ b/src/main/java/com/After_Buy/DeviceService/security/UserPrincipal.java
@@ -1,0 +1,61 @@
+package com.After_Buy.DeviceService.security;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * 스프링 시큐리티 유저 컨텍스트 모델
+ * JWT 검증 필터를 통과한 정상 사용자의 인증 정보를 시큐리티 컨텍스트에
+ * 체류시키기 위한 UserDetails 구현체입니다. user_id만 보유합니다.
+ *
+ * @since : 2026.04.06
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@RequiredArgsConstructor
+public class UserPrincipal implements UserDetails {
+
+	// JWT 페이로드에서 추출된 사용자 DB PK
+	private final Long userId;
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return List.of();
+	}
+
+	@Override
+	public String getPassword() {
+		return null;
+	}
+
+	@Override
+	public String getUsername() {
+		return String.valueOf(this.userId);
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+}

--- a/src/main/java/com/After_Buy/DeviceService/service/DeviceService.java
+++ b/src/main/java/com/After_Buy/DeviceService/service/DeviceService.java
@@ -1,0 +1,89 @@
+package com.After_Buy.DeviceService.service;
+
+import com.After_Buy.DeviceService.dto.request.DeviceRegisterRequest;
+import com.After_Buy.DeviceService.dto.response.DeviceResponse;
+import com.After_Buy.DeviceService.entity.Device;
+import com.After_Buy.DeviceService.exception.CustomException;
+import com.After_Buy.DeviceService.exception.ErrorCode;
+import com.After_Buy.DeviceService.repository.DeviceRepository;
+import com.After_Buy.DeviceService.repository.FolderRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+/**
+ * 기기 비즈니스 로직 서비스
+ * 기기 CRUD 관련 핵심 비즈니스 로직을 처리합니다.
+ *
+ * @since : 2026.04.06
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DeviceService {
+
+	private final DeviceRepository deviceRepository;
+	private final FolderRepository folderRepository;
+
+	/**
+	 * 기기 등록 메소드
+	 * 클라이언트로부터 받은 등록 요청으로 새 기기를 DB에 저장합니다.
+	 *
+	 * 처리 흐름:
+	 * 1. folder_id가 있을 경우 폴더 존재 여부 및 소유권 검증 (실패 시 DEVICE-001 404)
+	 * 2. image_url 정보는 null을 허용합니다 (선택 사항).
+	 * 3. warranty_expiry_date = purchase_date + warranty_months 자동 계산
+	 * 4. Device 엔티티 저장 후 DeviceResponse 반환
+	 *
+	 * @param userId  : JWT 토큰에서 추출한 인증된 사용자 ID
+	 * @param request : 기기 등록 요청 DTO
+	 * @return : 저장된 기기 전체 정보 응답 DTO
+	 * @throws CustomException : folder_id가 존재하지 않거나 본인 폴더가 아닌 경우 (DEVICE-001, 404)
+	 */
+	@Transactional
+	public DeviceResponse registerDevice(Long userId, DeviceRegisterRequest request) {
+		/* 1. folder_id 검증: null이 아닐 때만 검증 수행 */
+		if (request.getFolderId() != null) {
+			boolean isFolderValid = folderRepository
+					.findByFolderIdAndUserId(request.getFolderId(), userId)
+					.isPresent();
+
+			if (!isFolderValid) {
+				/* folder_id가 존재하지 않거나 본인 폴더가 아닌 경우 → API 명세서: DEVICE-001, 404 */
+				log.warn("폴더 검증 실패: folderId={}, userId={}", request.getFolderId(), userId);
+				throw new CustomException(ErrorCode.DEVICE_FOLDER_NOT_FOUND);
+			}
+		}
+
+		/* 2. warranty_expiry_date 자동 계산: purchase_date + warranty_months */
+		LocalDate warrantyExpiryDate = request.getPurchaseDate().plusMonths(request.getWarrantyMonths());
+
+		/* 4. Device 엔티티 Builder 패턴으로 생성 후 저장 */
+		Device device = Device.builder()
+				.userId(userId)
+				.folderId(request.getFolderId())
+				.productName(request.getProductName())
+				.modelName(request.getModelName())
+				.brand(request.getBrand())
+				.imageUrl(request.getImageUrl())
+				.productLinkUrl(request.getProductLinkUrl())
+				.purchaseDate(request.getPurchaseDate())
+				.purchasePrice(request.getPurchasePrice())
+				.purchaseStore(request.getPurchaseStore())
+				.warrantyMonths(request.getWarrantyMonths())
+				.warrantyExpiryDate(warrantyExpiryDate)
+				.serialNumber(request.getSerialNumber())
+				.memo(request.getMemo())
+				.build();
+
+		Device savedDevice = deviceRepository.save(device);
+		log.info("기기 등록 완료: deviceId={}, userId={}", savedDevice.getDeviceId(), userId);
+
+		return DeviceResponse.from(savedDevice);
+	}
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -37,3 +37,18 @@ spring:
   #       static: ${AWS_REGION}
   #     s3:
   #       bucket: ${AWS_S3_BUCKET}
+
+# 내부 서비스 통신용 시크릿 키 (MSA 내부 API 접근 보안)
+internal:
+  secret-key: ${INTERNAL_SECRET_KEY}
+
+# JWT 설정 (Auth Service와 동일한 비밀키 공유 — 토큰 검증 전용)
+jwt:
+  secret: ${JWT_SECRET}
+  access-expiration: ${JWT_ACCESS_EXPIRATION:3600000}
+  refresh-expiration: ${JWT_REFRESH_EXPIRATION:1209600000}
+
+# 네이버 쇼핑 외부 API 연동 정보 (.env 매핑)
+naver:
+  client-id: ${NAVER_CLIENT_ID}
+  client-secret: ${NAVER_CLIENT_SECRET}

--- a/src/test/java/com/After_Buy/DeviceService/DeviceServiceApplicationTests.java
+++ b/src/test/java/com/After_Buy/DeviceService/DeviceServiceApplicationTests.java
@@ -3,7 +3,10 @@ package com.After_Buy.DeviceService;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import org.springframework.test.context.ActiveProfiles;
+
 @SpringBootTest
+@ActiveProfiles("test")
 class DeviceServiceApplicationTests {
 
 	@Test

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,0 +1,28 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password: 
+  
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+# Secret Keys (테스트를 위해 임의의 값 설정)
+jwt:
+  secret: a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6A7B8C9D0E1F2
+  access-expiration: 3600000
+  refresh-expiration: 1209600000
+
+internal:
+  secret: "test-internal-secret-token"
+
+naver:
+  client-id: "test-client-id"
+  client-secret: "test-client-secret"


### PR DESCRIPTION
## 📌 개요
#### 제품 등록 API 구현



## 🛠️ 작업 내용
- 제품 등록 API 관련 코드 (Controller, Service, Repository, Entity, DTO) 작성
- AuthService의 인증정보 불러오기 (로그인 API 호출하여 AccessToken 발급 받기)
- build.gradle에 누락되었던 SpringSecurity 의존성 추가
- 인증 관련 코드 (Security,config) 작성
- 스웨거 API 테스트를 위한 코드 작성
- 테스트 시 folder_id가 0으로 설정되어 양식대로 제출 시 에러 발생 -> 스웨거 default 설정 값을 0에서 null로 변경하여 테스트 단순화
- API 테스트 성공


## ✅ 체크리스트
- [X] 코드 컨벤션을 준수했나요?
- [X] 테스트를 완료했나요?
- [X] 불필요한 주석을 제거했나요?

## 📸 스크린샷 (선택)
<img width="1425" height="832" alt="image" src="https://github.com/user-attachments/assets/df19aac0-50a0-4c9f-abdc-3bda1ff1c24e" />
