### PR TITLE
fix: GHCR 로그인 토큰을 PAT(GHCR_TOKEN)으로 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,7 +83,7 @@ jobs:
             ENVEOF
 
             cd ~/after-buy-infra
-            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             docker-compose -f docker-compose.yml -f docker-compose.dev.yml pull device-service
             docker-compose -f docker-compose.yml -f docker-compose.dev.yml rm -f device-service
             docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d device-service
@@ -127,7 +127,7 @@ jobs:
             ENVEOF
 
             cd ~/after-buy-infra
-            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             docker-compose -f docker-compose.yml -f docker-compose.prod.yml pull device-service
             docker-compose -f docker-compose.yml -f docker-compose.prod.yml rm -f device-service
             docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d device-service


### PR DESCRIPTION
## 변경 사항
- EC2 SSH 세션 내 GHCR 로그인 토큰을 `GITHUB_TOKEN` → `GHCR_TOKEN`으로 변경

## 변경 이유
- `GITHUB_TOKEN`은 GitHub Actions 워크플로우 내부에서만 유효
- SSH로 EC2에 접속한 세션에서는 `GITHUB_TOKEN`의 scope가 전달되지 않아 GHCR pull 실패 가능
- 별도 발급한 PAT(Personal Access Token)를 `GHCR_TOKEN` Secret으로 등록하여 사용

## 영향 범위
- `.github/workflows/deploy.yml` (deploy-dev, deploy-prod 두 곳)
