### PR TITLE
[FEAT] 네이버 검색 결과 호출 API 연동 완료

### DIFF
--- a/src/main/java/com/After_Buy/DeviceService/controller/DeviceController.java
+++ b/src/main/java/com/After_Buy/DeviceService/controller/DeviceController.java
@@ -59,11 +59,15 @@ public class DeviceController {
 	}
 
 	/**
-	 * 모델명 기반 제품 검색 API
+	 * 모델명 기반 제품 검색 메소드
 	 * OCR 등으로 추출된 제품의 고유 모델명을 기반으로 네이버 쇼핑 API 검색을 수행하여, 가장 연관성이 높은 최상단의 제품 데이터를 가져옵니다.
 	 *
 	 * @param modelName : 검색할 고유 모델명 (예: SM-G991N)
 	 * @return : 200 OK + NaverProductDto (클라이언트에 반영될 정제된 제품 메타 정보)
+	 * @since : 2026.04.07
+	 * @version : 1.0.0
+	 * @throws : Exception
+	 * @author : 최준혁
 	 */
 	@Operation(summary = "제조사 및 제품 정보 자동 매핑", description = "제품의 고유 모델명을 입력하면 네이버 쇼핑 엔진의 정확도 순(유사도) 매치 결과를 통해 브랜드명, 제품 이미지 URL, 구매처 링크 등을 매핑해옵니다.")
 	@GetMapping("/naver-search")

--- a/src/main/java/com/After_Buy/DeviceService/controller/DeviceController.java
+++ b/src/main/java/com/After_Buy/DeviceService/controller/DeviceController.java
@@ -3,8 +3,10 @@ package com.After_Buy.DeviceService.controller;
 import com.After_Buy.DeviceService.dto.request.DeviceRegisterRequest;
 import com.After_Buy.DeviceService.dto.response.ApiResponse;
 import com.After_Buy.DeviceService.dto.response.DeviceResponse;
+import com.After_Buy.DeviceService.dto.response.NaverProductDto;
 import com.After_Buy.DeviceService.security.UserPrincipal;
 import com.After_Buy.DeviceService.service.DeviceService;
+import com.After_Buy.DeviceService.service.NaverSearchService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -34,6 +36,7 @@ import org.springframework.web.bind.annotation.*;
 public class DeviceController {
 
 	private final DeviceService deviceService;
+	private final NaverSearchService naverSearchService;
 
 	/**
 	 * 기기 등록 API
@@ -53,5 +56,20 @@ public class DeviceController {
 		log.info("기기 등록 요청: userId={}", userPrincipal.getUserId());
 		DeviceResponse response = deviceService.registerDevice(userPrincipal.getUserId(), request);
 		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+	}
+
+	/**
+	 * 모델명 기반 제품 검색 API
+	 * OCR 등으로 추출된 제품의 고유 모델명을 기반으로 네이버 쇼핑 API 검색을 수행하여, 가장 연관성이 높은 최상단의 제품 데이터를 가져옵니다.
+	 *
+	 * @param modelName : 검색할 고유 모델명 (예: SM-G991N)
+	 * @return : 200 OK + NaverProductDto (클라이언트에 반영될 정제된 제품 메타 정보)
+	 */
+	@Operation(summary = "제조사 및 제품 정보 자동 매핑", description = "제품의 고유 모델명을 입력하면 네이버 쇼핑 엔진의 정확도 순(유사도) 매치 결과를 통해 브랜드명, 제품 이미지 URL, 구매처 링크 등을 매핑해옵니다.")
+	@GetMapping("/naver-search")
+	public ResponseEntity<ApiResponse<NaverProductDto>> getProductFromNaver(@RequestParam("modelName") String modelName) {
+		log.info("네이버 쇼핑 API 모델명 검색 요청: modelName={}", modelName);
+		NaverProductDto response = naverSearchService.searchProduct(modelName);
+		return ResponseEntity.ok(ApiResponse.success(response));
 	}
 }

--- a/src/main/java/com/After_Buy/DeviceService/dto/response/NaverProductDto.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/response/NaverProductDto.java
@@ -3,6 +3,14 @@ package com.After_Buy.DeviceService.dto.response;
 import lombok.Builder;
 import lombok.Getter;
 
+/**
+ * 네이버 쇼핑 제품 정보 전송 DTO
+ * 내부적으로 정제시킨 네이버 쇼핑 검색 결과를 클라이언트(프론트엔드)로 반환할 때 사용하는 DTO 입니다.
+ *
+ * @since : 2026.04.07
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
 @Getter
 @Builder
 public class NaverProductDto {

--- a/src/main/java/com/After_Buy/DeviceService/dto/response/NaverProductDto.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/response/NaverProductDto.java
@@ -1,0 +1,14 @@
+package com.After_Buy.DeviceService.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NaverProductDto {
+    private String productName;
+    private String modelName;
+    private String brand;
+    private String imageUrl;
+    private String productLinkUrl;
+}

--- a/src/main/java/com/After_Buy/DeviceService/dto/response/NaverSearchResponse.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/response/NaverSearchResponse.java
@@ -1,0 +1,26 @@
+package com.After_Buy.DeviceService.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NaverSearchResponse {
+    private List<Item> items;
+
+    @Getter
+    @Setter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Item {
+        private String title;
+        private String link;
+        private String image;
+        private String mallName;
+        private String maker;
+        private String brand;
+    }
+}

--- a/src/main/java/com/After_Buy/DeviceService/dto/response/NaverSearchResponse.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/response/NaverSearchResponse.java
@@ -6,6 +6,14 @@ import lombok.Setter;
 
 import java.util.List;
 
+/**
+ * 네이버 쇼핑 검색 결과 바인딩용 DTO
+ * 네이버 쇼핑 Open API의 JSON 응답 데이터를 매핑하기 위해 사용되는 내부 DTO 입니다.
+ *
+ * @since : 2026.04.07
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
 @Getter
 @Setter
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/com/After_Buy/DeviceService/exception/ErrorCode.java
+++ b/src/main/java/com/After_Buy/DeviceService/exception/ErrorCode.java
@@ -25,6 +25,11 @@ public enum ErrorCode {
 	/** 기기가 존재하지 않거나 본인 소유가 아닌 경우 */
 	DEVICE_NOT_FOUND(HttpStatus.NOT_FOUND, "DEVICE-002", "존재하지 않거나 접근 권한이 없는 기기입니다."),
 
+	/* ===== 검색 대행 관련 (SEARCH-0XX) ===== */
+
+	/** 네이버 쇼핑 API 검색 결과 없음 */
+	SEARCH_NO_RESULT(HttpStatus.NOT_FOUND, "SEARCH-001", "검색 결과가 없습니다. 직접 입력해주세요."),
+
 	/* ===== OCR 관련 (OCR-0XX) ===== */
 
 	/** OCR 텍스트 인식 실패 */

--- a/src/main/java/com/After_Buy/DeviceService/service/NaverSearchService.java
+++ b/src/main/java/com/After_Buy/DeviceService/service/NaverSearchService.java
@@ -1,0 +1,96 @@
+package com.After_Buy.DeviceService.service;
+
+import com.After_Buy.DeviceService.dto.response.NaverProductDto;
+import com.After_Buy.DeviceService.dto.response.NaverSearchResponse;
+import com.After_Buy.DeviceService.exception.CustomException;
+import com.After_Buy.DeviceService.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.HtmlUtils;
+
+@Slf4j
+@Service
+public class NaverSearchService {
+
+    private final WebClient webClient;
+    private final String clientId;
+    private final String clientSecret;
+
+    public NaverSearchService(
+            WebClient.Builder webClientBuilder,
+            @Value("${naver.client-id}") String clientId,
+            @Value("${naver.client-secret}") String clientSecret) {
+        this.webClient = webClientBuilder.baseUrl("https://openapi.naver.com/v1/search").build();
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+    }
+
+    /**
+     * 모델명을 기반으로 네이버 쇼핑 API를 호출하여 가장 정확도(sim)가 높은 첫 번째 제품 데이터를 반환합니다.
+     * OCR에서 추출된 고유 모델명이 입력되는 것을 상정합니다.
+     *
+     * @param modelName 기기가 식별되는 고유 모델명
+     * @return NaverProductDto 변환된 검색 결과
+     * @throws CustomException 검색 결과가 없을 경우 에러 발생
+     */
+    public NaverProductDto searchProduct(String modelName) {
+        log.info("[NaverSearchService] Searching for model: {}", modelName);
+
+        NaverSearchResponse response = webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/shop.json")
+                        .queryParam("query", modelName)
+                        .queryParam("display", 1)  // 가장 유사도 높은 최상단 데이터 1개만 매핑
+                        .queryParam("sort", "sim") // 유사도(정확도) 순 정렬 명시
+                        .build())
+                .header("X-Naver-Client-Id", clientId)
+                .header("X-Naver-Client-Secret", clientSecret)
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .bodyToMono(NaverSearchResponse.class)
+                .block(); // 백엔드 프록시이므로 블로킹으로 결과를 대기
+
+        if (response == null || response.getItems() == null || response.getItems().isEmpty()) {
+            throw new CustomException(ErrorCode.SEARCH_NO_RESULT);
+        }
+
+        NaverSearchResponse.Item item = response.getItems().get(0);
+
+        // 네이버 API 응답의 title 등에 포함된 <b>, </b> 태그 등을 이스케이프 해제 및 정제
+        String cleanTitle = cleanHtmlTags(item.getTitle());
+
+        // 검색된 제품의 이름(cleanTitle)에 사용자가 입력한 모델명이 포함되어 있는지 엄격하게 검증 (띄어쓰기, 하이픈 무시)
+        if (!normalizeString(cleanTitle).contains(normalizeString(modelName))) {
+            log.warn("[NaverSearchService] 검색 결과가 요청한 모델명과 일치하지 않습니다. 매핑 거부. (조회된 상품: {}, 요청 모델명: {})", cleanTitle, modelName);
+            throw new CustomException(ErrorCode.SEARCH_NO_RESULT);
+        }
+
+        return NaverProductDto.builder()
+                .productName(cleanTitle)
+                .modelName(modelName)
+                .brand(item.getBrand() != null && !item.getBrand().isEmpty() ? item.getBrand() : item.getMaker())
+                .imageUrl(item.getImage())
+                .productLinkUrl(item.getLink())
+                .build();
+    }
+
+    /**
+     * 공백, 하이픈, 언더바 등을 제거하고 모두 대문자로 변환하여 엄격한 문자열 비교를 위한 정규화를 수행합니다.
+     */
+    private String normalizeString(String input) {
+        if (input == null) return "";
+        return input.replaceAll("[\\s\\-_]", "").toUpperCase();
+    }
+
+    /**
+     * HTML 태그(<b> 등)를 제거하고 이스케이프된 문자를 복원합니다.
+     */
+    private String cleanHtmlTags(String input) {
+        if (input == null) return null;
+        String unescaped = HtmlUtils.htmlUnescape(input);
+        return unescaped.replaceAll("<[^>]*>", "");
+    }
+}

--- a/src/main/java/com/After_Buy/DeviceService/service/NaverSearchService.java
+++ b/src/main/java/com/After_Buy/DeviceService/service/NaverSearchService.java
@@ -11,6 +11,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.HtmlUtils;
 
+/**
+ * 네이버 쇼핑 검색 서비스
+ * 제품의 모델명을 통해 네이버 쇼핑 API와 통신하여 정보를 추출하고 정제하는 서비스 클래스
+ *
+ * @since : 2026.04.07
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
 @Slf4j
 @Service
 public class NaverSearchService {
@@ -29,12 +37,16 @@ public class NaverSearchService {
     }
 
     /**
+     * 제품 모델명 검색 메소드
      * 모델명을 기반으로 네이버 쇼핑 API를 호출하여 가장 정확도(sim)가 높은 첫 번째 제품 데이터를 반환합니다.
      * OCR에서 추출된 고유 모델명이 입력되는 것을 상정합니다.
      *
-     * @param modelName 기기가 식별되는 고유 모델명
-     * @return NaverProductDto 변환된 검색 결과
-     * @throws CustomException 검색 결과가 없을 경우 에러 발생
+     * @param modelName : 기기가 식별되는 고유 모델명
+     * @return : NaverProductDto (변환 및 정제된 검색 결과)
+     * @since : 2026.04.07
+     * @version : 1.0.0
+     * @throws : CustomException (검색 결과가 없거나 모델명이 일치하지 않을 경우 SEARCH_NO_RESULT 에러 발생)
+     * @author : 최준혁
      */
     public NaverProductDto searchProduct(String modelName) {
         log.info("[NaverSearchService] Searching for model: {}", modelName);
@@ -78,7 +90,14 @@ public class NaverSearchService {
     }
 
     /**
+     * 모델명 데이터 정규화 처리 메소드
      * 공백, 하이픈, 언더바 등을 제거하고 모두 대문자로 변환하여 엄격한 문자열 비교를 위한 정규화를 수행합니다.
+     *
+     * @param input : 정규화할 원본 문자열
+     * @return : 공백과 특수기호가 제거된 대문자 문자열
+     * @since : 2026.04.07
+     * @version : 1.0.0
+     * @author : 최준혁
      */
     private String normalizeString(String input) {
         if (input == null) return "";
@@ -86,7 +105,14 @@ public class NaverSearchService {
     }
 
     /**
-     * HTML 태그(<b> 등)를 제거하고 이스케이프된 문자를 복원합니다.
+     * HTML 태그 제거 및 이스케이프 복원 메소드
+     * HTML <b> 등의 태그를 제거하고 이스케이프된 문자를 일반 문자열로 복원합니다.
+     *
+     * @param input : HTML 태그가 포함된 원본 문자열
+     * @return : HTML 태그가 제거된 순수 문자열
+     * @since : 2026.04.07
+     * @version : 1.0.0
+     * @author : 최준혁
      */
     private String cleanHtmlTags(String input) {
         if (input == null) return null;


### PR DESCRIPTION
## 📌 개요
#### 제품 모델명을 기반으로 네이버에 검색 후 네이버 스마트스토어의 제품 정보를 반환하는 API 구현 완료



## 🛠️ 작업 내용
- 네이버 API 호출하는 검색 API 정의
- 네이버 응답 파싱
- 네이버 응답을 기준으로 프론트 응답 DTO 생성



## ✅ 체크리스트
- [X] 코드 컨벤션을 준수했나요?
- [X] 테스트를 완료했나요?
- [X] 불필요한 주석을 제거했나요?

## 📸 스크린샷 (선택)
<img width="846" height="471" alt="image" src="https://github.com/user-attachments/assets/97bcc2d4-200a-4a58-8959-b3a27f2390d4" />
