### PR TITLE
[FEAT] 홈화면 요약 API 구현

### DIFF
--- a/src/main/java/com/After_Buy/DeviceService/controller/DeviceController.java
+++ b/src/main/java/com/After_Buy/DeviceService/controller/DeviceController.java
@@ -36,6 +36,24 @@ public class DeviceController {
 	private final DeviceService deviceService;
 
 	/**
+	 * 홈 화면 요약 데이터 조회 API
+	 * 사용자의 기기 통계(총 기기 수, 총 가치, 30일 내 만료), 기기 리스트(최근 3대), 보증 임박 기기(1대)를 반환합니다.
+	 *
+	 * @param userPrincipal : JWT 토큰에서 추출된 인증 사용자 정보
+	 * @return : 200 OK + 홈 화면 요약 응답 데이터
+	 * @since : 2026.04.08
+	 * @author : 최준혁
+	 */
+	@Operation(summary = "홈 화면 요약 데이터 조회", description = "보유 자산 통계, 최근 등록 3개, 보증 시간 가장 임박 1개 기기를 반환합니다.")
+	@GetMapping("/home-summary")
+	public ResponseEntity<ApiResponse<com.After_Buy.DeviceService.dto.response.HomeSummaryResponse>> getHomeSummary(
+			@AuthenticationPrincipal UserPrincipal userPrincipal) {
+		log.info("홈 화면 요약 조회 요청: userId={}", userPrincipal.getUserId());
+		com.After_Buy.DeviceService.dto.response.HomeSummaryResponse response = deviceService.getHomeSummary(userPrincipal.getUserId());
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
+	/**
 	 * 기기 등록 API
 	 * 새 기기를 등록합니다. warranty_expiry_date는 서버에서 purchase_date + warranty_months로 자동 계산 후 저장합니다.
 	 * image_url이 없을 경우 placeholder 이미지가 자동으로 삽입됩니다.

--- a/src/main/java/com/After_Buy/DeviceService/controller/DeviceController.java
+++ b/src/main/java/com/After_Buy/DeviceService/controller/DeviceController.java
@@ -3,6 +3,7 @@ package com.After_Buy.DeviceService.controller;
 import com.After_Buy.DeviceService.dto.request.DeviceRegisterRequest;
 import com.After_Buy.DeviceService.dto.response.ApiResponse;
 import com.After_Buy.DeviceService.dto.response.DeviceResponse;
+import com.After_Buy.DeviceService.dto.response.HomeSummaryResponse;
 import com.After_Buy.DeviceService.security.UserPrincipal;
 import com.After_Buy.DeviceService.service.DeviceService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -46,10 +47,10 @@ public class DeviceController {
 	 */
 	@Operation(summary = "홈 화면 요약 데이터 조회", description = "보유 자산 통계, 최근 등록 3개, 보증 시간 가장 임박 1개 기기를 반환합니다.")
 	@GetMapping("/home-summary")
-	public ResponseEntity<ApiResponse<com.After_Buy.DeviceService.dto.response.HomeSummaryResponse>> getHomeSummary(
+	public ResponseEntity<ApiResponse<HomeSummaryResponse>> getHomeSummary(
 			@AuthenticationPrincipal UserPrincipal userPrincipal) {
 		log.info("홈 화면 요약 조회 요청: userId={}", userPrincipal.getUserId());
-		com.After_Buy.DeviceService.dto.response.HomeSummaryResponse response = deviceService.getHomeSummary(userPrincipal.getUserId());
+		HomeSummaryResponse response = deviceService.getHomeSummary(userPrincipal.getUserId());
 		return ResponseEntity.ok(ApiResponse.success(response));
 	}
 

--- a/src/main/java/com/After_Buy/DeviceService/dto/response/HomeDeviceDto.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/response/HomeDeviceDto.java
@@ -1,0 +1,36 @@
+package com.After_Buy.DeviceService.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 홈 화면용 기기 요약 DTO
+ * 최근 등록된 기기와 보증 만료가 가장 임박한 기기 정보를 담습니다.
+ * null 값인 필드는 JSON 응답에서 제외됩니다.
+ *
+ * @since : 2026.04.08
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class HomeDeviceDto {
+    private Long device_id;
+    private String product_name;
+    private String model_name;
+    private String brand;
+    private String image_url;
+    private String product_link_url;
+    private LocalDate warranty_expiry_date;
+    private Long days_remaining;
+    private LocalDateTime created_at;
+}

--- a/src/main/java/com/After_Buy/DeviceService/dto/response/HomeSummaryResponse.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/response/HomeSummaryResponse.java
@@ -1,0 +1,25 @@
+package com.After_Buy.DeviceService.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 홈 화면 요약 응답 DTO
+ * 
+ * @since : 2026.04.08
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class HomeSummaryResponse {
+    private SummaryDto summary;
+    private List<HomeDeviceDto> recent_devices;
+    private HomeDeviceDto urgent_device;
+}

--- a/src/main/java/com/After_Buy/DeviceService/dto/response/SummaryDto.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/response/SummaryDto.java
@@ -1,0 +1,28 @@
+package com.After_Buy.DeviceService.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+/**
+ * 홈 화면 요약 통계 DTO
+ * 
+ * @since : 2026.04.08
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SummaryDto {
+    // 사용자가 소유한 총 기기 수
+    private Integer total_devices;
+    // 사용자가 소유한 총 기기의 가치 (구매 가격 총합)
+    private BigDecimal total_value;
+    // 본래 오늘 기점으로 30일 이내에 보증이 만료되는 기기 수
+    private Integer expiring_soon_count;
+}

--- a/src/main/java/com/After_Buy/DeviceService/repository/DeviceRepository.java
+++ b/src/main/java/com/After_Buy/DeviceService/repository/DeviceRepository.java
@@ -2,6 +2,13 @@ package com.After_Buy.DeviceService.repository;
 
 import com.After_Buy.DeviceService.entity.Device;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * 기기 레포지토리
@@ -13,4 +20,22 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * @author : 최준혁
  */
 public interface DeviceRepository extends JpaRepository<Device, Long> {
+
+    // 사용자의 전체 기기 개수 조회
+    Long countByUserId(Long userId);
+
+    // 사용자의 등록 기기 가격들(가치)의 총합 조회
+    @Query("SELECT COALESCE(SUM(d.purchasePrice), 0) FROM Device d WHERE d.userId = :userId")
+    BigDecimal sumPurchasePriceByUserId(@Param("userId") Long userId);
+
+    // 보증 만료 기간이 다가오는(오늘부터 end_date 사이) 기기 개수 조회
+    @Query("SELECT COUNT(d) FROM Device d WHERE d.userId = :userId AND d.warrantyExpiryDate BETWEEN CURRENT_DATE AND :endDate")
+    Long countExpiringSoonByUserId(@Param("userId") Long userId, @Param("endDate") LocalDate endDate);
+
+    // 사용자의 가장 최근에 등록된 기기 최대 3대 조회
+    List<Device> findTop3ByUserIdOrderByCreatedAtDesc(Long userId);
+
+    // 현재 기점 가장 만료일이 근접한 1개의 기기 조회 (Native Query 이용)
+    @Query(value = "SELECT * FROM devices WHERE user_id = :userId ORDER BY ABS(DATEDIFF(warranty_expiry_date, CURRENT_DATE)) ASC LIMIT 1", nativeQuery = true)
+    Optional<Device> findTopByUserIdOrderByWarrantyExpiryDateClosest(@Param("userId") Long userId);
 }

--- a/src/main/java/com/After_Buy/DeviceService/security/JwtTokenProvider.java
+++ b/src/main/java/com/After_Buy/DeviceService/security/JwtTokenProvider.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
+import java.util.Date;
 
 /**
  * JWT 토큰 검증 전용 프로바이더
@@ -73,11 +74,11 @@ public class JwtTokenProvider {
 		return Jwts.parser().verifyWith(this.secretKey).build().parseSignedClaims(token).getPayload();
 	}
 
-	public java.util.Date getRefreshTokenExpiry() {
-		return new java.util.Date(System.currentTimeMillis() + this.refreshExpiration);
+	public Date getRefreshTokenExpiry() {
+		return new Date(System.currentTimeMillis() + this.refreshExpiration);
 	}
 
-	public java.util.Date getExpirationFromToken(String token) {
+	public Date getExpirationFromToken(String token) {
 		return parseClaims(token).getExpiration();
 	}
 }

--- a/src/main/java/com/After_Buy/DeviceService/service/DeviceService.java
+++ b/src/main/java/com/After_Buy/DeviceService/service/DeviceService.java
@@ -86,4 +86,70 @@ public class DeviceService {
 
 		return DeviceResponse.from(savedDevice);
 	}
+
+	/**
+	 * 홈 화면 데이터 요약 조회
+	 * 사용자의 기기 통계(총 기기 수, 총 가치, 30일 내 만료), 기기 리스트(최근 3대), 보증 임박 기기(1대)를 반환합니다.
+	 *
+	 * @param userId : 조회할 사용자 ID
+	 * @return : 홈 화면 요약 응답 객체
+	 */
+	@Transactional(readOnly = true)
+	public com.After_Buy.DeviceService.dto.response.HomeSummaryResponse getHomeSummary(Long userId) {
+		// 1. 자산 통계 조회
+		Long totalDevices = deviceRepository.countByUserId(userId);
+		java.math.BigDecimal totalValue = deviceRepository.sumPurchasePriceByUserId(userId);
+		LocalDate endDate = LocalDate.now().plusDays(30);
+		Long expiringSoonCount = deviceRepository.countExpiringSoonByUserId(userId, endDate);
+
+		com.After_Buy.DeviceService.dto.response.SummaryDto summary = com.After_Buy.DeviceService.dto.response.SummaryDto.builder()
+				.total_devices(totalDevices.intValue())
+				.total_value(totalValue)
+				.expiring_soon_count(expiringSoonCount.intValue())
+				.build();
+
+		// 2. 최근 등록된 기기 조회 (최대 3개)
+		java.util.List<Device> recents = deviceRepository.findTop3ByUserIdOrderByCreatedAtDesc(userId);
+		java.util.List<com.After_Buy.DeviceService.dto.response.HomeDeviceDto> recentDevices = recents.stream()
+				.map(device -> mapToHomeDeviceDto(device, true))
+				.collect(java.util.stream.Collectors.toList());
+
+		// 3. 가장 보증 만료가 임박한 기기 조회 (Native Query 이용)
+		java.util.Optional<Device> urgentDeviceOpt = deviceRepository.findTopByUserIdOrderByWarrantyExpiryDateClosest(userId);
+		com.After_Buy.DeviceService.dto.response.HomeDeviceDto urgentDevice = urgentDeviceOpt.map(device -> mapToHomeDeviceDto(device, false)).orElse(null);
+
+		return com.After_Buy.DeviceService.dto.response.HomeSummaryResponse.builder()
+				.summary(summary)
+				.recent_devices(recentDevices)
+				.urgent_device(urgentDevice)
+				.build();
+	}
+
+	/**
+	 * Device Entity -> HomeDeviceDto 매핑 유틸 메서드
+	 *
+	 * @param device   변환할 기기 엔티티
+	 * @param isRecent 최근 기기 리스트인지 여부 (true: modelName, createdAt 포함 / false: productLinkUrl 포함)
+	 * @return HomeDeviceDto 객체
+	 */
+	private com.After_Buy.DeviceService.dto.response.HomeDeviceDto mapToHomeDeviceDto(Device device, boolean isRecent) {
+		long remainingDays = java.time.temporal.ChronoUnit.DAYS.between(LocalDate.now(), device.getWarrantyExpiryDate());
+
+		com.After_Buy.DeviceService.dto.response.HomeDeviceDto.HomeDeviceDtoBuilder builder = com.After_Buy.DeviceService.dto.response.HomeDeviceDto.builder()
+				.device_id(device.getDeviceId())
+				.product_name(device.getProductName())
+				.brand(device.getBrand())
+				.image_url(device.getImageUrl())
+				.warranty_expiry_date(device.getWarrantyExpiryDate())
+				.days_remaining(remainingDays);
+
+		if (isRecent) {
+			builder.model_name(device.getModelName());
+			builder.created_at(device.getCreatedAt());
+		} else {
+			builder.product_link_url(device.getProductLinkUrl());
+		}
+
+		return builder.build();
+	}
 }

--- a/src/main/java/com/After_Buy/DeviceService/service/DeviceService.java
+++ b/src/main/java/com/After_Buy/DeviceService/service/DeviceService.java
@@ -2,6 +2,9 @@ package com.After_Buy.DeviceService.service;
 
 import com.After_Buy.DeviceService.dto.request.DeviceRegisterRequest;
 import com.After_Buy.DeviceService.dto.response.DeviceResponse;
+import com.After_Buy.DeviceService.dto.response.HomeDeviceDto;
+import com.After_Buy.DeviceService.dto.response.HomeSummaryResponse;
+import com.After_Buy.DeviceService.dto.response.SummaryDto;
 import com.After_Buy.DeviceService.entity.Device;
 import com.After_Buy.DeviceService.exception.CustomException;
 import com.After_Buy.DeviceService.exception.ErrorCode;
@@ -12,7 +15,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * 기기 비즈니스 로직 서비스
@@ -95,30 +103,32 @@ public class DeviceService {
 	 * @return : 홈 화면 요약 응답 객체
 	 */
 	@Transactional(readOnly = true)
-	public com.After_Buy.DeviceService.dto.response.HomeSummaryResponse getHomeSummary(Long userId) {
-		// 1. 자산 통계 조회
+	public HomeSummaryResponse getHomeSummary(Long userId) {
+		/* 1. 자산 통계 조회 */
 		Long totalDevices = deviceRepository.countByUserId(userId);
-		java.math.BigDecimal totalValue = deviceRepository.sumPurchasePriceByUserId(userId);
+		BigDecimal totalValue = deviceRepository.sumPurchasePriceByUserId(userId);
 		LocalDate endDate = LocalDate.now().plusDays(30);
 		Long expiringSoonCount = deviceRepository.countExpiringSoonByUserId(userId, endDate);
 
-		com.After_Buy.DeviceService.dto.response.SummaryDto summary = com.After_Buy.DeviceService.dto.response.SummaryDto.builder()
+		SummaryDto summary = SummaryDto.builder()
 				.total_devices(totalDevices.intValue())
 				.total_value(totalValue)
 				.expiring_soon_count(expiringSoonCount.intValue())
 				.build();
 
-		// 2. 최근 등록된 기기 조회 (최대 3개)
-		java.util.List<Device> recents = deviceRepository.findTop3ByUserIdOrderByCreatedAtDesc(userId);
-		java.util.List<com.After_Buy.DeviceService.dto.response.HomeDeviceDto> recentDevices = recents.stream()
+		/* 2. 최근 등록된 기기 조회 (최대 3개) */
+		List<Device> recents = deviceRepository.findTop3ByUserIdOrderByCreatedAtDesc(userId);
+		List<HomeDeviceDto> recentDevices = recents.stream()
 				.map(device -> mapToHomeDeviceDto(device, true))
-				.collect(java.util.stream.Collectors.toList());
+				.collect(Collectors.toList());
 
-		// 3. 가장 보증 만료가 임박한 기기 조회 (Native Query 이용)
-		java.util.Optional<Device> urgentDeviceOpt = deviceRepository.findTopByUserIdOrderByWarrantyExpiryDateClosest(userId);
-		com.After_Buy.DeviceService.dto.response.HomeDeviceDto urgentDevice = urgentDeviceOpt.map(device -> mapToHomeDeviceDto(device, false)).orElse(null);
+		/* 3. 가장 보증 만료가 임박한 기기 조회 (Native Query 이용) */
+		Optional<Device> urgentDeviceOpt = deviceRepository.findTopByUserIdOrderByWarrantyExpiryDateClosest(userId);
+		HomeDeviceDto urgentDevice = urgentDeviceOpt
+				.map(device -> mapToHomeDeviceDto(device, false))
+				.orElse(null);
 
-		return com.After_Buy.DeviceService.dto.response.HomeSummaryResponse.builder()
+		return HomeSummaryResponse.builder()
 				.summary(summary)
 				.recent_devices(recentDevices)
 				.urgent_device(urgentDevice)
@@ -132,10 +142,10 @@ public class DeviceService {
 	 * @param isRecent 최근 기기 리스트인지 여부 (true: modelName, createdAt 포함 / false: productLinkUrl 포함)
 	 * @return HomeDeviceDto 객체
 	 */
-	private com.After_Buy.DeviceService.dto.response.HomeDeviceDto mapToHomeDeviceDto(Device device, boolean isRecent) {
-		long remainingDays = java.time.temporal.ChronoUnit.DAYS.between(LocalDate.now(), device.getWarrantyExpiryDate());
+	private HomeDeviceDto mapToHomeDeviceDto(Device device, boolean isRecent) {
+		long remainingDays = ChronoUnit.DAYS.between(LocalDate.now(), device.getWarrantyExpiryDate());
 
-		com.After_Buy.DeviceService.dto.response.HomeDeviceDto.HomeDeviceDtoBuilder builder = com.After_Buy.DeviceService.dto.response.HomeDeviceDto.builder()
+		HomeDeviceDto.HomeDeviceDtoBuilder builder = HomeDeviceDto.builder()
 				.device_id(device.getDeviceId())
 				.product_name(device.getProductName())
 				.brand(device.getBrand())


### PR DESCRIPTION
## 📌 개요
#### 홈화면 정보 API 구현 완료



## 🛠️ 작업 내용
- 요약 정보, 최근 등록 기기 3개 보증 만료 임박 기기 1개 반환 API 구현 완료
- develop 브랜치와 머지 충돌 발생 -> develop을 브랜치에 머지하여 충돌 해결



## ✅ 체크리스트
- [X] 코드 컨벤션을 준수했나요?
- [X] 테스트를 완료했나요?
- [X] 불필요한 주석을 제거했나요?

## 📸 스크린샷 (선택)
<img width="941" height="686" alt="image" src="https://github.com/user-attachments/assets/c1ffaa11-d103-4d8e-90c3-9c0c496f6226" />
