### PR TITLE
[FEAT] 미분류 제품 조회 및 제품 상세 조회 api 구현

### DIFF
--- a/src/main/java/com/After_Buy/DeviceService/controller/DeviceController.java
+++ b/src/main/java/com/After_Buy/DeviceService/controller/DeviceController.java
@@ -5,6 +5,8 @@ import com.After_Buy.DeviceService.dto.response.ApiResponse;
 import com.After_Buy.DeviceService.dto.response.DeviceResponse;
 import com.After_Buy.DeviceService.dto.response.NaverProductDto;
 import com.After_Buy.DeviceService.dto.response.HomeSummaryResponse;
+import com.After_Buy.DeviceService.dto.response.DeviceListResponse;
+import com.After_Buy.DeviceService.dto.response.DeviceDetailResponse;
 import com.After_Buy.DeviceService.security.UserPrincipal;
 import com.After_Buy.DeviceService.service.DeviceService;
 import com.After_Buy.DeviceService.service.NaverSearchService;
@@ -98,6 +100,48 @@ public class DeviceController {
 			@RequestParam("modelName") String modelName) {
 		log.info("네이버 쇼핑 API 모델명 검색 요청: modelName={}", modelName);
 		NaverProductDto response = naverSearchService.searchProduct(modelName);
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
+	/**
+	 * 미분류 기기 목록 조회 API
+	 * 미분류(folder_id = NULL) 상태의 기기 목록을 조회합니다.
+	 * 
+	 * @param userPrincipal : JWT 토큰에서 추출된 인증 사용자 정보
+	 * @param sort : 정렬 조건 (created_desc: 최신등록순(기본값), expiry_asc: 보증만료임박순)
+	 * @return : 200 OK + 미분류 기기 목록(DeviceListResponse)
+	 * @since : 2026.04.08
+	 * @author : 최준혁
+	 */
+	@Operation(summary = "미분류 기기 목록 조회", description = "폴더에 속하지 않은 미분류 기기 목록을 정렬 조건에 따라 조회합니다.")
+	@GetMapping
+	public ResponseEntity<ApiResponse<DeviceListResponse>> getDeviceList(
+			@AuthenticationPrincipal UserPrincipal userPrincipal,
+			@RequestParam(value = "sort", defaultValue = "created_desc") String sort) {
+		log.info("미분류 기기 목록 조회 요청: userId={}, sort={}", userPrincipal.getUserId(), sort);
+		DeviceListResponse response = deviceService.getDeviceList(userPrincipal.getUserId(), sort);
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
+	/**
+	 * 기기 상세 내역 조회 API
+	 * 기기 ID를 기반으로 해당 기기의 모든 상세 정보와 보증 잔여 일수 실시간 계산 결과를 조회합니다.
+	 * 
+	 * @param userPrincipal : JWT 토큰에서 추출된 인증 사용자 정보
+	 * @param deviceId : 조회할 대상 기기의 고유 ID
+	 * @return : 200 OK + 상세 기기 정보(DeviceDetailResponse)
+	 * @throws com.After_Buy.DeviceService.exception.CustomException :
+	 *             본인 기기가 아닌 경우 DEVICE-002 (403), 존재하지 않는 경우 DEVICE-003 (404)
+	 * @since : 2026.04.08
+	 * @author : 최준혁
+	 */
+	@Operation(summary = "기기 상세 내역 조회", description = "특정 기기의 상세 정보와 실시간 보증 잔여 일수를 반환합니다. 본인의 기기만 조회할 수 있습니다.")
+	@GetMapping("/{device_id}")
+	public ResponseEntity<ApiResponse<DeviceDetailResponse>> getDeviceDetail(
+			@AuthenticationPrincipal UserPrincipal userPrincipal,
+			@PathVariable("device_id") Long deviceId) {
+		log.info("기기 상세 정보 조회 요청: userId={}, deviceId={}", userPrincipal.getUserId(), deviceId);
+		DeviceDetailResponse response = deviceService.getDeviceDetail(userPrincipal.getUserId(), deviceId);
 		return ResponseEntity.ok(ApiResponse.success(response));
 	}
 }

--- a/src/main/java/com/After_Buy/DeviceService/dto/request/DeviceRegisterRequest.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/request/DeviceRegisterRequest.java
@@ -1,5 +1,7 @@
 package com.After_Buy.DeviceService.dto.request;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 import lombok.Getter;
@@ -22,6 +24,7 @@ import java.time.LocalDate;
  */
 @Getter
 @NoArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class DeviceRegisterRequest {
 
 	/* ===== 선택 항목 ===== */

--- a/src/main/java/com/After_Buy/DeviceService/dto/response/DeviceDetailResponse.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/response/DeviceDetailResponse.java
@@ -9,20 +9,22 @@ import lombok.Getter;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 /**
- * 기기 응답 DTO
- * POST /api/devices 성공(201 Created) 응답 및 GET /api/devices/{device_id} 응답에 사용됩니다.
- * API 명세서의 201 Created 응답 구조와 동일합니다.
+ * 기기 상세 조회 응답 DTO
+ * GET /api/devices/{device_id} 성공(200 OK) 응답에 사용됩니다.
+ * days_remaining은 API 명세서에 따라 서버에서 warranty_expiry_date - 현재 날짜로 실시간 계산됩니다.
+ * POST(기기 등록) 응답인 DeviceResponse와 달리 days_remaining 필드를 포함합니다.
  *
- * @since : 2026.04.06
+ * @since : 2026.04.08
  * @version : 1.0.0
  * @author : 최준혁
  */
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class DeviceResponse {
+public class DeviceDetailResponse {
 
 	// 기기 고유 ID
 	private final Long deviceId;
@@ -42,7 +44,7 @@ public class DeviceResponse {
 	// 브랜드명
 	private final String brand;
 
-	// 기기 이미지 URL (null 시 placeholder 이미지 적용됨)
+	// 기기 이미지 URL
 	private final String imageUrl;
 
 	// 공식 제품 페이지 URL
@@ -60,7 +62,7 @@ public class DeviceResponse {
 	// 무상 보증 기간 개월 수
 	private final Integer warrantyMonths;
 
-	// 보증 만료일 (purchase_date + warranty_months 자동 계산)
+	// 보증 만료일
 	private final LocalDate warrantyExpiryDate;
 
 	// 시리얼 넘버
@@ -69,6 +71,9 @@ public class DeviceResponse {
 	// 사용자 메모
 	private final String memo;
 
+	/* 보증 잔여 일수 (서버 실시간 계산: warranty_expiry_date - 오늘, 음수 = 이미 만료됨) */
+	private final Long daysRemaining;
+
 	// 등록 일시
 	private final LocalDateTime createdAt;
 
@@ -76,17 +81,19 @@ public class DeviceResponse {
 	private final LocalDateTime updatedAt;
 
 	/**
-	 * Device 엔티티로부터 응답 DTO를 생성하는 정적 팩토리 메소드
-	 * Entity → DTO 변환을 일관되게 처리합니다.
+	 * Device 엔티티로부터 상세 응답 DTO를 생성하는 정적 팩토리 메소드
 	 *
 	 * @param device : 변환할 Device 엔티티
-	 * @return : 클라이언트에 반환할 DeviceResponse DTO
+	 * @return : 클라이언트에 반환할 DeviceDetailResponse DTO
+	 * @since : 2026.04.08
+	 * @version : 1.0.0
+	 * @author : 최준혁
 	 */
-	public static DeviceResponse from(Device device) {
-		return new DeviceResponse(device);
+	public static DeviceDetailResponse from(Device device) {
+		return new DeviceDetailResponse(device);
 	}
 
-	private DeviceResponse(Device device) {
+	private DeviceDetailResponse(Device device) {
 		this.deviceId = device.getDeviceId();
 		this.userId = device.getUserId();
 		this.folderId = device.getFolderId();
@@ -102,6 +109,8 @@ public class DeviceResponse {
 		this.warrantyExpiryDate = device.getWarrantyExpiryDate();
 		this.serialNumber = device.getSerialNumber();
 		this.memo = device.getMemo();
+		/* days_remaining: warranty_expiry_date - 현재 날짜 (API 명세서: 서버에서 실시간 계산) */
+		this.daysRemaining = ChronoUnit.DAYS.between(LocalDate.now(), device.getWarrantyExpiryDate());
 		this.createdAt = device.getCreatedAt();
 		this.updatedAt = device.getUpdatedAt();
 	}

--- a/src/main/java/com/After_Buy/DeviceService/dto/response/DeviceListItemDto.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/response/DeviceListItemDto.java
@@ -1,0 +1,77 @@
+package com.After_Buy.DeviceService.dto.response;
+
+import com.After_Buy.DeviceService.entity.Device;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * 기기 목록 아이템 응답 DTO
+ * GET /api/devices 응답에 사용되는 기기 목록 아이템 DTO입니다.
+ * days_remaining은 서버에서 warranty_expiry_date - 현재 날짜로 실시간 계산됩니다.
+ *
+ * @since : 2026.04.08
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class DeviceListItemDto {
+
+	// 기기 고유 ID
+	private final Long deviceId;
+
+	// 소속 폴더 ID (null = 미분류)
+	private final Long folderId;
+
+	// 상품명
+	private final String productName;
+
+	// 모델명
+	private final String modelName;
+
+	// 브랜드명
+	private final String brand;
+
+	// 기기 이미지 URL
+	private final String imageUrl;
+
+	// 보증 만료일
+	private final LocalDate warrantyExpiryDate;
+
+	// 보증 잔여 일수 (서버 실시간 계산: warranty_expiry_date - 오늘)
+	private final Long daysRemaining;
+
+	// 등록 일시
+	private final LocalDateTime createdAt;
+
+	/**
+	 * Device 엔티티로부터 목록 아이템 DTO를 생성하는 정적 팩토리 메소드
+	 *
+	 * @param device : 변환할 Device 엔티티
+	 * @return : DeviceListItemDto 객체
+	 * @since : 2026.04.08
+	 * @version : 1.0.0
+	 * @author : 최준혁
+	 */
+	public static DeviceListItemDto from(Device device) {
+		return new DeviceListItemDto(device);
+	}
+
+	private DeviceListItemDto(Device device) {
+		this.deviceId = device.getDeviceId();
+		this.folderId = device.getFolderId();
+		this.productName = device.getProductName();
+		this.modelName = device.getModelName();
+		this.brand = device.getBrand();
+		this.imageUrl = device.getImageUrl();
+		this.warrantyExpiryDate = device.getWarrantyExpiryDate();
+		/* days_remaining: warranty_expiry_date - 현재 날짜 (음수 = 이미 만료됨) */
+		this.daysRemaining = ChronoUnit.DAYS.between(LocalDate.now(), device.getWarrantyExpiryDate());
+		this.createdAt = device.getCreatedAt();
+	}
+}

--- a/src/main/java/com/After_Buy/DeviceService/dto/response/DeviceListResponse.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/response/DeviceListResponse.java
@@ -1,0 +1,41 @@
+package com.After_Buy.DeviceService.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 기기 목록 조회 응답 래퍼 DTO
+ * GET /api/devices의 응답 데이터 최상위 구조입니다.
+ * API 명세: { "success": true, "data": { "devices": [...] } }
+ *
+ * @since : 2026.04.08
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class DeviceListResponse {
+
+	// 기기 목록 (folder_id = NULL인 미분류 기기만 포함)
+	private final List<DeviceListItemDto> devices;
+
+	/**
+	 * 기기 목록 응답 생성 정적 팩토리 메소드
+	 *
+	 * @param devices : 기기 목록 아이템 DTO 리스트
+	 * @return : DeviceListResponse 객체
+	 * @since : 2026.04.08
+	 * @version : 1.0.0
+	 * @author : 최준혁
+	 */
+	public static DeviceListResponse of(List<DeviceListItemDto> devices) {
+		return new DeviceListResponse(devices);
+	}
+
+	private DeviceListResponse(List<DeviceListItemDto> devices) {
+		this.devices = devices;
+	}
+}

--- a/src/main/java/com/After_Buy/DeviceService/exception/ErrorCode.java
+++ b/src/main/java/com/After_Buy/DeviceService/exception/ErrorCode.java
@@ -22,8 +22,11 @@ public enum ErrorCode {
 	/** 폴더가 존재하지 않거나 본인 소유가 아닌 경우 */
 	DEVICE_FOLDER_NOT_FOUND(HttpStatus.NOT_FOUND, "DEVICE-001", "존재하지 않거나 접근 권한이 없는 폴더입니다."),
 
-	/** 기기가 존재하지 않거나 본인 소유가 아닌 경우 */
-	DEVICE_NOT_FOUND(HttpStatus.NOT_FOUND, "DEVICE-002", "존재하지 않거나 접근 권한이 없는 기기입니다."),
+	/** 본인의 기기가 아닌 경우 (403 Forbidden) */
+	DEVICE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "DEVICE-002", "본인의 기기에만 접근할 수 있습니다."),
+
+	/** 기기가 존재하지 않는 경우 (404 Not Found) */
+	DEVICE_NOT_FOUND(HttpStatus.NOT_FOUND, "DEVICE-003", "존재하지 않는 기기입니다."),
 
 	/* ===== 검색 대행 관련 (SEARCH-0XX) ===== */
 

--- a/src/main/java/com/After_Buy/DeviceService/repository/DeviceRepository.java
+++ b/src/main/java/com/After_Buy/DeviceService/repository/DeviceRepository.java
@@ -38,4 +38,10 @@ public interface DeviceRepository extends JpaRepository<Device, Long> {
     // 현재 기점 가장 만료일이 근접한 1개의 기기 조회 (Native Query 이용)
     @Query(value = "SELECT * FROM devices WHERE user_id = :userId ORDER BY ABS(DATEDIFF(warranty_expiry_date, CURRENT_DATE)) ASC LIMIT 1", nativeQuery = true)
     Optional<Device> findTopByUserIdOrderByWarrantyExpiryDateClosest(@Param("userId") Long userId);
+
+    // 미분류 기기 목록 조회 (최신 등록순)
+    List<Device> findByUserIdAndFolderIdIsNullOrderByCreatedAtDesc(Long userId);
+
+    // 미분류 기기 목록 조회 (보증 만료 임박순)
+    List<Device> findByUserIdAndFolderIdIsNullOrderByWarrantyExpiryDateAsc(Long userId);
 }

--- a/src/main/java/com/After_Buy/DeviceService/service/DeviceService.java
+++ b/src/main/java/com/After_Buy/DeviceService/service/DeviceService.java
@@ -4,6 +4,9 @@ import com.After_Buy.DeviceService.dto.request.DeviceRegisterRequest;
 import com.After_Buy.DeviceService.dto.response.DeviceResponse;
 import com.After_Buy.DeviceService.dto.response.HomeDeviceDto;
 import com.After_Buy.DeviceService.dto.response.HomeSummaryResponse;
+import com.After_Buy.DeviceService.dto.response.DeviceListResponse;
+import com.After_Buy.DeviceService.dto.response.DeviceListItemDto;
+import com.After_Buy.DeviceService.dto.response.DeviceDetailResponse;
 import com.After_Buy.DeviceService.dto.response.SummaryDto;
 import com.After_Buy.DeviceService.entity.Device;
 import com.After_Buy.DeviceService.exception.CustomException;
@@ -161,5 +164,53 @@ public class DeviceService {
 		}
 
 		return builder.build();
+	}
+
+	/**
+	 * 미분류 기기 목록 조회
+	 * folder_id가 null인 미분류 기기 목록을 정렬 조건에 따라 조회합니다.
+	 *
+	 * @param userId 조회할 사용자 ID
+	 * @param sort 정렬 조건 (created_desc: 최신순, expiry_asc: 보증 만료 임박순)
+	 * @return DeviceListResponse (미분류 기기 목록)
+	 */
+	@Transactional(readOnly = true)
+	public DeviceListResponse getDeviceList(Long userId, String sort) {
+		List<Device> devices;
+		if ("expiry_asc".equalsIgnoreCase(sort)) {
+			devices = deviceRepository.findByUserIdAndFolderIdIsNullOrderByWarrantyExpiryDateAsc(userId);
+		} else {
+			// 기본값은 created_desc
+			devices = deviceRepository.findByUserIdAndFolderIdIsNullOrderByCreatedAtDesc(userId);
+		}
+
+		List<DeviceListItemDto> deviceItems = devices.stream()
+				.map(DeviceListItemDto::from)
+				.collect(Collectors.toList());
+
+		return DeviceListResponse.of(deviceItems);
+	}
+
+	/**
+	 * 기기 상세 내역 조회
+	 * device_id를 기반으로 전체 기기 상세 정보를 조회합니다. 본인 소유가 아닌 경우 조회할 수 없습니다.
+	 *
+	 * @param userId 조회 요청을 한 사용자 ID (JWT)
+	 * @param deviceId 조회할 대상 기기 ID
+	 * @return DeviceDetailResponse (기기 상세 정보)
+	 * @throws CustomException 기기가 없을 경우 DEVICE_NOT_FOUND (404),
+	 *                         타인의 기기인 경우 DEVICE_ACCESS_DENIED (403)
+	 */
+	@Transactional(readOnly = true)
+	public DeviceDetailResponse getDeviceDetail(Long userId, Long deviceId) {
+		Device device = deviceRepository.findById(deviceId)
+				.orElseThrow(() -> new CustomException(ErrorCode.DEVICE_NOT_FOUND));
+
+		if (!device.getUserId().equals(userId)) {
+			log.warn("기기 접근 권한 없음: 요청 userId={}, device 소유 userId={}", userId, device.getUserId());
+			throw new CustomException(ErrorCode.DEVICE_ACCESS_DENIED);
+		}
+
+		return DeviceDetailResponse.from(device);
 	}
 }


### PR DESCRIPTION
## 📌 개요
#### 미분류 제품 조회 및 제품 상세 조회 API 구현 완료



## 🛠️ 작업 내용
- 미분류 제품 조회 API 구현
- 제품 상세 조회 API 구현
- json 필드 형식 snake_case로 리팩토링



## ✅ 체크리스트
- [X] 코드 컨벤션을 준수했나요?
- [X] 테스트를 완료했나요?
- [X] 불필요한 주석을 제거했나요?

## 📸 스크린샷 (선택)
<img width="949" height="714" alt="image" src="https://github.com/user-attachments/assets/18cdf85e-63c6-4af2-9619-991111ced721" />
<img width="936" height="641" alt="image" src="https://github.com/user-attachments/assets/49f09e06-0333-4e81-aae0-8f5effa70b7e" />
