### PR TITLE
[FEAT] 전자기기 수정 API 구현

### DIFF
--- a/src/main/java/com/After_Buy/DeviceService/controller/DeviceController.java
+++ b/src/main/java/com/After_Buy/DeviceService/controller/DeviceController.java
@@ -1,12 +1,15 @@
 package com.After_Buy.DeviceService.controller;
 
 import com.After_Buy.DeviceService.dto.request.DeviceRegisterRequest;
+import com.After_Buy.DeviceService.dto.request.DeviceUpdateRequest;
+import com.After_Buy.DeviceService.dto.request.DeviceNameUpdateRequest;
 import com.After_Buy.DeviceService.dto.response.ApiResponse;
 import com.After_Buy.DeviceService.dto.response.DeviceResponse;
 import com.After_Buy.DeviceService.dto.response.NaverProductDto;
 import com.After_Buy.DeviceService.dto.response.HomeSummaryResponse;
 import com.After_Buy.DeviceService.dto.response.DeviceListResponse;
 import com.After_Buy.DeviceService.dto.response.DeviceDetailResponse;
+import com.After_Buy.DeviceService.dto.response.DeviceNameUpdateResponse;
 import com.After_Buy.DeviceService.security.UserPrincipal;
 import com.After_Buy.DeviceService.service.DeviceService;
 import com.After_Buy.DeviceService.service.NaverSearchService;
@@ -142,6 +145,51 @@ public class DeviceController {
 			@PathVariable("device_id") Long deviceId) {
 		log.info("기기 상세 정보 조회 요청: userId={}, deviceId={}", userPrincipal.getUserId(), deviceId);
 		DeviceDetailResponse response = deviceService.getDeviceDetail(userPrincipal.getUserId(), deviceId);
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
+	/**
+	 * 기기 정보 전체 수정 API
+	 * 기기의 전체 정보(model_name 제외)를 갱신합니다. 무상 보증 기간이나 구매일이 변경될 경우
+	 * 보증 만료일은 서버에서 자동 재계산됩니다.
+	 *
+	 * @param userPrincipal : JWT 토큰에서 추출된 인증 사용자 정보
+	 * @param deviceId : 수정할 대상 기기의 고유 ID
+	 * @param request : 기기 수정 데이터
+	 * @return : 200 OK + 수정된 상세 기기 정보(DeviceDetailResponse)
+	 * @since : 2026.04.08
+	 * @author : 최준혁
+	 */
+	@Operation(summary = "기기 정보 갱신", description = "기기 정보를 전체 교체합니다. model_name은 수정할 수 없으며, 구매일/보증조건 변경 시 보증 만료일이 자동 갱신됩니다.")
+	@PutMapping("/{device_id}")
+	public ResponseEntity<ApiResponse<DeviceDetailResponse>> updateDevice(
+			@AuthenticationPrincipal UserPrincipal userPrincipal,
+			@PathVariable("device_id") Long deviceId,
+			@Valid @RequestBody DeviceUpdateRequest request) {
+		log.info("기기 정보 전체 수정 요청: userId={}, deviceId={}", userPrincipal.getUserId(), deviceId);
+		DeviceDetailResponse response = deviceService.updateDevice(userPrincipal.getUserId(), deviceId, request);
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
+	/**
+	 * 기기 상품명 단일 수정 API
+	 * 아이템 목록 화면 등의 메뉴에서 상품명만 간편하게 변경할 때 사용됩니다.
+	 * 
+	 * @param userPrincipal : JWT 토큰에서 추출된 인증 사용자 정보
+	 * @param deviceId : 수정할 대상 기기의 고유 ID
+	 * @param request : 변경할 상품명 데이터
+	 * @return : 200 OK + 단일 수정 응답 객체
+	 * @since : 2026.04.08
+	 * @author : 최준혁
+	 */
+	@Operation(summary = "기기 상품명 단일 수정", description = "아이템 목록 화면에서 상품명만 간단히 변경할 때 호출합니다.")
+	@PatchMapping("/{device_id}/name")
+	public ResponseEntity<ApiResponse<DeviceNameUpdateResponse>> updateDeviceName(
+			@AuthenticationPrincipal UserPrincipal userPrincipal,
+			@PathVariable("device_id") Long deviceId,
+			@Valid @RequestBody DeviceNameUpdateRequest request) {
+		log.info("기기 상품명 단일 수정 요청: userId={}, deviceId={}, newProductName={}", userPrincipal.getUserId(), deviceId, request.getProductName());
+		DeviceNameUpdateResponse response = deviceService.updateDeviceName(userPrincipal.getUserId(), deviceId, request);
 		return ResponseEntity.ok(ApiResponse.success(response));
 	}
 }

--- a/src/main/java/com/After_Buy/DeviceService/dto/request/DeviceNameUpdateRequest.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/request/DeviceNameUpdateRequest.java
@@ -1,0 +1,27 @@
+package com.After_Buy.DeviceService.dto.request;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 기기 상품명 수정 요청 DTO
+ * PATCH /api/devices/{device_id}/name 호출 시 사용됩니다.
+ *
+ * @since : 2026.04.08
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@NoArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class DeviceNameUpdateRequest {
+
+	// 상품명 (필수, 최대 200자)
+	@NotBlank(message = "상품명은 필수 입력값입니다.")
+	@Size(max = 200, message = "상품명은 200자 이내여야 합니다.")
+	private String productName;
+}

--- a/src/main/java/com/After_Buy/DeviceService/dto/request/DeviceUpdateRequest.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/request/DeviceUpdateRequest.java
@@ -1,0 +1,73 @@
+package com.After_Buy.DeviceService.dto.request;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * 기기 정보 전체 수정 요청 DTO
+ * PUT /api/devices/{device_id} 통신에 사용됩니다.
+ * API 명세서에 따라 model_name을 제외한 나머지 정보를 모두 입력받아 업데이트합니다.
+ *
+ * @since : 2026.04.08
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@NoArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class DeviceUpdateRequest {
+
+	// 소속 폴더 ID (null = 미분류 상태)
+	@Schema(description = "소속 폴더 ID (미분류 시 null)", nullable = true, example = "null")
+	private Long folderId;
+
+	// 상품명 (필수, 최대 200자)
+	@NotBlank(message = "상품명은 필수 입력값입니다.")
+	@Size(max = 200, message = "상품명은 200자 이내여야 합니다.")
+	private String productName;
+
+	// 브랜드명 (필수, 최대 100자)
+	@NotBlank(message = "브랜드명은 필수 입력값입니다.")
+	@Size(max = 100, message = "브랜드명은 100자 이내여야 합니다.")
+	private String brand;
+
+	// 기기 이미지 URL (선택)
+	@Size(max = 500, message = "이미지 URL은 500자 이내여야 합니다.")
+	private String imageUrl;
+
+	// 공식 제품 페이지 URL (선택)
+	@Size(max = 500, message = "제품 링크 URL은 500자 이내여야 합니다.")
+	private String productLinkUrl;
+
+	// 구매일 (필수, YYYY-MM-DD 형식)
+	@NotNull(message = "구매일은 필수 입력값입니다.")
+	private LocalDate purchaseDate;
+
+	// 구매 가격 (필수)
+	@NotNull(message = "구매 가격은 필수 입력값입니다.")
+	@DecimalMin(value = "0.0", inclusive = false, message = "구매 가격은 0보다 커야 합니다.")
+	private BigDecimal purchasePrice;
+
+	// 구매처 (선택)
+	@Size(max = 100, message = "구매처는 100자 이내여야 합니다.")
+	private String purchaseStore;
+
+	// 무상 보증 기간 개월 수 (필수)
+	@NotNull(message = "무상 보증 기간은 필수 입력값입니다.")
+	@Min(value = 1, message = "무상 보증 기간은 1개월 이상이어야 합니다.")
+	private Integer warrantyMonths;
+
+	// 시리얼 넘버 (선택)
+	@Size(max = 100, message = "시리얼 넘버는 100자 이내여야 합니다.")
+	private String serialNumber;
+
+	// 사용자 메모 (선택)
+	private String memo;
+}

--- a/src/main/java/com/After_Buy/DeviceService/dto/response/DeviceNameUpdateResponse.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/response/DeviceNameUpdateResponse.java
@@ -1,0 +1,35 @@
+package com.After_Buy.DeviceService.dto.response;
+
+import com.After_Buy.DeviceService.entity.Device;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 기기 상품명 수정 응답 DTO
+ * PATCH /api/devices/{device_id}/name 성공 데이터
+ *
+ * @since : 2026.04.08
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class DeviceNameUpdateResponse {
+
+	private final Long deviceId;
+	private final String productName;
+	private final LocalDateTime updatedAt;
+
+	public static DeviceNameUpdateResponse from(Device device) {
+		return new DeviceNameUpdateResponse(device);
+	}
+
+	private DeviceNameUpdateResponse(Device device) {
+		this.deviceId = device.getDeviceId();
+		this.productName = device.getProductName();
+		this.updatedAt = device.getUpdatedAt();
+	}
+}

--- a/src/main/java/com/After_Buy/DeviceService/entity/Device.java
+++ b/src/main/java/com/After_Buy/DeviceService/entity/Device.java
@@ -107,20 +107,20 @@ public class Device {
 	 * 기기 등록 Builder 생성자
 	 * Service 계층에서 등록 시 사용하며, warrantyExpiryDate는 Service에서 자동 계산하여 주입합니다.
 	 *
-	 * @param userId              : 소유 사용자 ID
-	 * @param folderId            : 소속 폴더 ID (null = 미분류)
-	 * @param productName         : 상품명
-	 * @param modelName           : 모델명
-	 * @param brand               : 브랜드명
-	 * @param imageUrl            : 이미지 URL
-	 * @param productLinkUrl      : 제품 링크 URL
-	 * @param purchaseDate        : 구매일
-	 * @param purchasePrice       : 구매 가격
-	 * @param purchaseStore       : 구매처
-	 * @param warrantyMonths      : 보증 기간(개월)
-	 * @param warrantyExpiryDate  : 보증 만료일 (자동 계산)
-	 * @param serialNumber        : 시리얼 넘버
-	 * @param memo                : 메모
+	 * @param userId             : 소유 사용자 ID
+	 * @param folderId           : 소속 폴더 ID (null = 미분류)
+	 * @param productName        : 상품명
+	 * @param modelName          : 모델명
+	 * @param brand              : 브랜드명
+	 * @param imageUrl           : 이미지 URL
+	 * @param productLinkUrl     : 제품 링크 URL
+	 * @param purchaseDate       : 구매일
+	 * @param purchasePrice      : 구매 가격
+	 * @param purchaseStore      : 구매처
+	 * @param warrantyMonths     : 보증 기간(개월)
+	 * @param warrantyExpiryDate : 보증 만료일 (자동 계산)
+	 * @param serialNumber       : 시리얼 넘버
+	 * @param memo               : 메모
 	 */
 	@Builder
 	public Device(Long userId, Long folderId, String productName, String modelName, String brand,
@@ -141,5 +141,55 @@ public class Device {
 		this.warrantyExpiryDate = warrantyExpiryDate;
 		this.serialNumber = serialNumber;
 		this.memo = memo;
+	}
+
+	/**
+	 * 기기 정보 전체 수정 (model_name 제외)
+	 * API 명세서 요구사항에 따라 warranty_months 또는 purchase_date 변경 시
+	 * warranty_expiry_date가 자동 재계산됩니다.
+	 *
+	 * @param folderId       : 소속 폴더 ID (미분류 시 null)
+	 * @param productName    : 상품명
+	 * @param brand          : 브랜드명
+	 * @param imageUrl       : 기기 이미지 URL
+	 * @param productLinkUrl : 공식 제품 페이지 URL
+	 * @param purchaseDate   : 구매일
+	 * @param purchasePrice  : 구매 가격
+	 * @param purchaseStore  : 구매처
+	 * @param warrantyMonths : 무상 보증 기간 개월 수
+	 * @param serialNumber   : 시리얼 넘버
+	 * @param memo           : 사용자 메모
+	 * @since : 2026.04.08
+	 * @author : 최준혁
+	 */
+	public void update(Long folderId, String productName, String brand, String imageUrl,
+			String productLinkUrl, LocalDate purchaseDate, BigDecimal purchasePrice,
+			String purchaseStore, Integer warrantyMonths, String serialNumber, String memo) {
+		this.folderId = folderId;
+		this.productName = productName;
+		this.brand = brand;
+		this.imageUrl = imageUrl;
+		this.productLinkUrl = productLinkUrl;
+		this.purchaseDate = purchaseDate;
+		this.purchasePrice = purchasePrice;
+		this.purchaseStore = purchaseStore;
+		this.warrantyMonths = warrantyMonths;
+		this.serialNumber = serialNumber;
+		this.memo = memo;
+
+		/* warranty_expiry_date 자동 갱신: 구매일 + 보증기간(개월) */
+		this.warrantyExpiryDate = this.purchaseDate.plusMonths(this.warrantyMonths);
+	}
+
+	/**
+	 * 기기 상품명 단일 수정
+	 * PATCH /api/devices/{device_id}/name 용
+	 *
+	 * @param productName : 변경할 상품명
+	 * @since : 2026.04.08
+	 * @author : 최준혁
+	 */
+	public void updateName(String productName) {
+		this.productName = productName;
 	}
 }

--- a/src/main/java/com/After_Buy/DeviceService/service/DeviceService.java
+++ b/src/main/java/com/After_Buy/DeviceService/service/DeviceService.java
@@ -1,12 +1,15 @@
 package com.After_Buy.DeviceService.service;
 
 import com.After_Buy.DeviceService.dto.request.DeviceRegisterRequest;
+import com.After_Buy.DeviceService.dto.request.DeviceUpdateRequest;
+import com.After_Buy.DeviceService.dto.request.DeviceNameUpdateRequest;
 import com.After_Buy.DeviceService.dto.response.DeviceResponse;
 import com.After_Buy.DeviceService.dto.response.HomeDeviceDto;
 import com.After_Buy.DeviceService.dto.response.HomeSummaryResponse;
 import com.After_Buy.DeviceService.dto.response.DeviceListResponse;
 import com.After_Buy.DeviceService.dto.response.DeviceListItemDto;
 import com.After_Buy.DeviceService.dto.response.DeviceDetailResponse;
+import com.After_Buy.DeviceService.dto.response.DeviceNameUpdateResponse;
 import com.After_Buy.DeviceService.dto.response.SummaryDto;
 import com.After_Buy.DeviceService.entity.Device;
 import com.After_Buy.DeviceService.exception.CustomException;
@@ -212,5 +215,76 @@ public class DeviceService {
 		}
 
 		return DeviceDetailResponse.from(device);
+	}
+
+	/**
+	 * 기기 정보 전체 수정 (model_name 제외)
+	 * API: PUT /api/devices/{device_id}
+	 * 
+	 * @param userId   : JWT에서 추출한 사용자 ID
+	 * @param deviceId : 수정대상 기기 ID
+	 * @param request  : 수정 데이터
+	 * @return DeviceDetailResponse : 수정된 내용이 반영된 상세 정보
+	 */
+	@Transactional
+	public DeviceDetailResponse updateDevice(Long userId, Long deviceId, DeviceUpdateRequest request) {
+		Device device = deviceRepository.findById(deviceId)
+				.orElseThrow(() -> new CustomException(ErrorCode.DEVICE_NOT_FOUND));
+
+		if (!device.getUserId().equals(userId)) {
+			log.warn("기기 수정 권한 없음: 요청 userId={}, device 소유 userId={}", userId, device.getUserId());
+			throw new CustomException(ErrorCode.DEVICE_ACCESS_DENIED);
+		}
+
+		/* folder_id 검증 */
+		if (request.getFolderId() != null) {
+			boolean isFolderValid = folderRepository
+					.findByFolderIdAndUserId(request.getFolderId(), userId)
+					.isPresent();
+			if (!isFolderValid) {
+				log.warn("기기 수정 실패 - 폴더 미존재 또는 권한 없음: folderId={}, userId={}", request.getFolderId(), userId);
+				throw new CustomException(ErrorCode.DEVICE_FOLDER_NOT_FOUND);
+			}
+		}
+
+		device.update(
+				request.getFolderId(),
+				request.getProductName(),
+				request.getBrand(),
+				request.getImageUrl(),
+				request.getProductLinkUrl(),
+				request.getPurchaseDate(),
+				request.getPurchasePrice(),
+				request.getPurchaseStore(),
+				request.getWarrantyMonths(),
+				request.getSerialNumber(),
+				request.getMemo()
+		);
+
+		return DeviceDetailResponse.from(device);
+	}
+
+	/**
+	 * 기기 상품명 단일 수정
+	 * API: PATCH /api/devices/{device_id}/name
+	 * 
+	 * @param userId   : JWT에서 추출한 사용자 ID
+	 * @param deviceId : 수정대상 기기 ID
+	 * @param request  : 상품명 수정 요청
+	 * @return DeviceNameUpdateResponse : 수정된 정보
+	 */
+	@Transactional
+	public DeviceNameUpdateResponse updateDeviceName(Long userId, Long deviceId, DeviceNameUpdateRequest request) {
+		Device device = deviceRepository.findById(deviceId)
+				.orElseThrow(() -> new CustomException(ErrorCode.DEVICE_NOT_FOUND));
+
+		if (!device.getUserId().equals(userId)) {
+			log.warn("기기 상품명 수정 권한 없음: 요청 userId={}, device 소유 userId={}", userId, device.getUserId());
+			throw new CustomException(ErrorCode.DEVICE_ACCESS_DENIED);
+		}
+
+		device.updateName(request.getProductName());
+
+		return DeviceNameUpdateResponse.from(device);
 	}
 }

--- a/src/main/java/com/After_Buy/DeviceService/service/DeviceService.java
+++ b/src/main/java/com/After_Buy/DeviceService/service/DeviceService.java
@@ -285,6 +285,9 @@ public class DeviceService {
 
 		device.updateName(request.getProductName());
 
-		return DeviceNameUpdateResponse.from(device);
+		/* @UpdateTimestamp는 flush 전까지 갱신되지 않으므로 saveAndFlush로 즉시 반영 */
+		Device savedDevice = deviceRepository.saveAndFlush(device);
+
+		return DeviceNameUpdateResponse.from(savedDevice);
 	}
 }


### PR DESCRIPTION
## 📌 개요
#### 전자기기 수정 API 및 제품명 수정 API 구현 완료



## 🛠️ 작업 내용
- 기기 상세 정보 페이지에서 수정 시 작동하는 PUT API 개발
- 아이템 목록(폴더) 페이지에서 기기명만 수정하는 PATCH API 개발
- API 호출 시 updated_at 미수정 가능성 위험 발견 및 조치


## ✅ 체크리스트
- [X] 코드 컨벤션을 준수했나요?
- [X] 테스트를 완료했나요?
- [X] 불필요한 주석을 제거했나요?

## 📸 스크린샷 (선택)
<img width="817" height="608" alt="image" src="https://github.com/user-attachments/assets/6a66a946-5499-41ad-81f2-5d943c8c9416" />
<img width="1077" height="511" alt="image" src="https://github.com/user-attachments/assets/bde1e422-9113-4e24-8265-a41863b24718" />
<img width="848" height="625" alt="image" src="https://github.com/user-attachments/assets/06163fc4-323a-463f-9662-aa4fc4ebcbe1" />
