### PR TITLE
[FEAT] 폴더/기기 일괄 이동 및 삭제 API 구현

### DIFF
--- a/src/main/java/com/After_Buy/DeviceService/controller/FolderController.java
+++ b/src/main/java/com/After_Buy/DeviceService/controller/FolderController.java
@@ -23,6 +23,8 @@ import jakarta.validation.Valid;
 
 import com.After_Buy.DeviceService.dto.request.FolderCreateRequest;
 import com.After_Buy.DeviceService.dto.request.FolderUpdateNameRequest;
+import com.After_Buy.DeviceService.dto.request.BulkMoveRequest;
+import com.After_Buy.DeviceService.dto.request.BulkDeleteRequest;
 import com.After_Buy.DeviceService.dto.response.FolderCreateResponse;
 import com.After_Buy.DeviceService.dto.response.FolderItemsResponse;
 
@@ -155,6 +157,52 @@ public class FolderController {
         folderService.deleteFolder(userPrincipal.getUserId(), folderId);
         
         return ResponseEntity.ok(ApiResponse.successMessage("폴더 및 내부 항목이 모두 삭제되었습니다."));
+    }
+
+    /**
+     * 폴더/기기 일괄 이동 API
+     * 선택한 여러 개의 폴더 및 기기들을 특정 폴더(루트 포함) 내로 한 번에 이동시킵니다.
+     *
+     * @param userPrincipal : 인증된 사용자
+     * @param request       : 이동 요청 데이터 (대상 ID 리스트들과 타겟 폴더 ID)
+     * @return : 200 OK + 성공 메시지
+     * @since : 2026.04.09
+     * @author : 최준혁
+     */
+    @Operation(summary = "폴더/기기 일괄 이동", description = "선택한 폴더 및 기기들을 특정 이동 대상 폴더로 옮깁니다.")
+    @PatchMapping("/bulk-move")
+    public ResponseEntity<ApiResponse<Void>> bulkMove(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody BulkMoveRequest request) {
+        log.info("항목 일괄 이동 요청: userId={}, folders={}, devices={}, targetFolderId={}", 
+                 userPrincipal.getUserId(), request.getFolderIds(), request.getDeviceIds(), request.getTargetFolderId());
+                 
+        folderService.bulkMove(userPrincipal.getUserId(), request);
+        
+        return ResponseEntity.ok(ApiResponse.successMessage("항목이 이동되었습니다."));
+    }
+
+    /**
+     * 폴더/기기 일괄 삭제 API
+     * 선택한 여러 개의 폴더 및 기기들을 연쇄 삭제합니다.
+     *
+     * @param userPrincipal : 인증된 사용자
+     * @param request       : 삭제 요청 데이터 (대상 ID 리스트들)
+     * @return : 200 OK + 성공 메시지
+     * @since : 2026.04.09
+     * @author : 최준혁
+     */
+    @Operation(summary = "폴더/기기 일괄 삭제", description = "선택한 폴더 및 기기들을 모두 삭제합니다.")
+    @DeleteMapping("/bulk-delete")
+    public ResponseEntity<ApiResponse<Void>> bulkDelete(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody BulkDeleteRequest request) {
+        log.info("항목 일괄 삭제 요청: userId={}, folders={}, devices={}", 
+                 userPrincipal.getUserId(), request.getFolderIds(), request.getDeviceIds());
+                 
+        folderService.bulkDelete(userPrincipal.getUserId(), request);
+        
+        return ResponseEntity.ok(ApiResponse.successMessage("선택한 항목이 삭제되었습니다."));
     }
 }
 

--- a/src/main/java/com/After_Buy/DeviceService/dto/request/BulkDeleteRequest.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/request/BulkDeleteRequest.java
@@ -3,6 +3,8 @@ package com.After_Buy.DeviceService.dto.request;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 
 import java.util.List;
 
@@ -16,6 +18,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class BulkDeleteRequest {
 
     /** 삭제할 폴더 ID 목록 */

--- a/src/main/java/com/After_Buy/DeviceService/dto/request/BulkDeleteRequest.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/request/BulkDeleteRequest.java
@@ -1,0 +1,26 @@
+package com.After_Buy.DeviceService.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 다중 폴더 및 기기 일괄 삭제 요청 DTO
+ * 
+ * @since : 2026.04.09
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BulkDeleteRequest {
+
+    /** 삭제할 폴더 ID 목록 */
+    private List<Long> folderIds;
+
+    /** 삭제할 기기 ID 목록 */
+    private List<Long> deviceIds;
+}

--- a/src/main/java/com/After_Buy/DeviceService/dto/request/BulkMoveRequest.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/request/BulkMoveRequest.java
@@ -3,6 +3,8 @@ package com.After_Buy.DeviceService.dto.request;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 
 import java.util.List;
 
@@ -16,6 +18,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class BulkMoveRequest {
 
     /** 이동할 폴더 ID 목록 */

--- a/src/main/java/com/After_Buy/DeviceService/dto/request/BulkMoveRequest.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/request/BulkMoveRequest.java
@@ -1,0 +1,29 @@
+package com.After_Buy.DeviceService.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 다중 폴더 및 기기 일괄 이동 요청 DTO
+ * 
+ * @since : 2026.04.09
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BulkMoveRequest {
+
+    /** 이동할 폴더 ID 목록 */
+    private List<Long> folderIds;
+
+    /** 이동할 기기 ID 목록 */
+    private List<Long> deviceIds;
+
+    /** 이동 대상이 되는 새로운 부모 폴더 ID (NULL 이면 루트로 이동) */
+    private Long targetFolderId;
+}

--- a/src/main/java/com/After_Buy/DeviceService/entity/Device.java
+++ b/src/main/java/com/After_Buy/DeviceService/entity/Device.java
@@ -192,4 +192,13 @@ public class Device {
 	public void updateName(String productName) {
 		this.productName = productName;
 	}
+
+	/**
+	 * 기기 이동 메서드
+	 *
+	 * @param folderId : 이동할 목적지 폴더 ID (루트로 이동 시 null)
+	 */
+	public void updateFolderId(Long folderId) {
+		this.folderId = folderId;
+	}
 }

--- a/src/main/java/com/After_Buy/DeviceService/entity/Folder.java
+++ b/src/main/java/com/After_Buy/DeviceService/entity/Folder.java
@@ -64,5 +64,14 @@ public class Folder {
 	public void updateFolderName(String folderName) {
 		this.folderName = folderName;
 	}
+
+	/**
+	 * 폴더 이동 메서드
+	 *
+	 * @param parentFolderId : 이동할 부모 폴더 ID (루트로 이동 시 null)
+	 */
+	public void updateParentFolderId(Long parentFolderId) {
+		this.parentFolderId = parentFolderId;
+	}
 }
 

--- a/src/main/java/com/After_Buy/DeviceService/exception/ErrorCode.java
+++ b/src/main/java/com/After_Buy/DeviceService/exception/ErrorCode.java
@@ -37,6 +37,11 @@ public enum ErrorCode {
 	/** 부모 폴더 미존재 (404 Not Found) */
 	PARENT_FOLDER_NOT_FOUND(HttpStatus.NOT_FOUND, "DEVICE-005", "존재하지 않는 상위 폴더입니다."),
 
+	/** 일괄 처리 대상 항목 없음 (400 Bad Request) */
+	BULK_ACTION_EMPTY_SELECTION(HttpStatus.BAD_REQUEST, "DEVICE-006", "요청할 폴더 또는 기기를 하나 이상 선택해야 합니다."),
+
+	/** 타인 소유 물품 권한 없음 (403 Forbidden) */
+	BULK_ACTION_ACCESS_DENIED(HttpStatus.FORBIDDEN, "DEVICE-007", "본인 소유의 항목만 접근할 수 있습니다."),
 
 	/* ===== 검색 대행 관련 (SEARCH-0XX) ===== */
 

--- a/src/main/java/com/After_Buy/DeviceService/service/FolderService.java
+++ b/src/main/java/com/After_Buy/DeviceService/service/FolderService.java
@@ -20,6 +20,8 @@ import com.After_Buy.DeviceService.dto.response.BreadcrumbDto;
 import com.After_Buy.DeviceService.dto.response.FolderCreateResponse;
 import com.After_Buy.DeviceService.dto.request.FolderCreateRequest;
 import com.After_Buy.DeviceService.dto.request.FolderUpdateNameRequest;
+import com.After_Buy.DeviceService.dto.request.BulkMoveRequest;
+import com.After_Buy.DeviceService.dto.request.BulkDeleteRequest;
 import com.After_Buy.DeviceService.entity.Folder;
 import com.After_Buy.DeviceService.exception.CustomException;
 import com.After_Buy.DeviceService.exception.ErrorCode;
@@ -206,6 +208,121 @@ public class FolderService {
         for (Long subId : subFolderIds) {
             deleteSubFoldersAndDevicesRecursively(subId);
             folderRepository.deleteById(subId);
+        }
+    }
+
+    /**
+     * 다중 항목 일괄 이동 로직
+     * 폴더와 기기들을 일괄 이동시킵니다.
+     *
+     * @param userId  : 이동을 요청하는 유저 ID
+     * @param request : 이동 항목들의 리스트와 최종 도달 폴더 ID
+     * @since : 2026.04.09
+     * @author : 최준혁
+     */
+    @Transactional
+    public void bulkMove(Long userId, BulkMoveRequest request) {
+        List<Long> folderIds = request.getFolderIds();
+        List<Long> deviceIds = request.getDeviceIds();
+
+        boolean isFolderIdsEmpty = (folderIds == null || folderIds.isEmpty());
+        boolean isDeviceIdsEmpty = (deviceIds == null || deviceIds.isEmpty());
+
+        // 1. 빈 리스트 점검 (DEVICE-006)
+        if (isFolderIdsEmpty && isDeviceIdsEmpty) {
+            throw new CustomException(ErrorCode.BULK_ACTION_EMPTY_SELECTION);
+        }
+
+        // 2. 타겟 폴더 상태 및 모순 검증
+        Long targetFolderId = request.getTargetFolderId();
+        if (targetFolderId != null) {
+            // 대상 폴더 존재 유무(DEVICE-005) 및 소유권 여부(DEVICE-004) 확인
+            Folder targetFolder = folderRepository.findById(targetFolderId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.FOLDER_NOT_FOUND));
+
+            if (!targetFolder.getUserId().equals(userId)) {
+                throw new CustomException(ErrorCode.FOLDER_ACCESS_DENIED);
+            }
+
+            // 폴더를 본인 스스로 포함하도록 이동 요청하는 루프 차단
+            if (!isFolderIdsEmpty && folderIds.contains(targetFolderId)) {
+                throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+            }
+        }
+
+        // 3. 폴더들 소유권 검수 및 부모 변경
+        if (!isFolderIdsEmpty) {
+            List<Folder> folders = folderRepository.findAllById(folderIds);
+            for (Folder folder : folders) {
+                if (!folder.getUserId().equals(userId)) {
+                    throw new CustomException(ErrorCode.BULK_ACTION_ACCESS_DENIED);
+                }
+                folder.updateParentFolderId(targetFolderId);
+            }
+        }
+
+        // 4. 기기들 소유권 검수 및 폴더 주소 변경
+        if (!isDeviceIdsEmpty) {
+            List<Device> devices = deviceRepository.findAllById(deviceIds);
+            for (Device device : devices) {
+                if (!device.getUserId().equals(userId)) {
+                    throw new CustomException(ErrorCode.BULK_ACTION_ACCESS_DENIED);
+                }
+                device.updateFolderId(targetFolderId);
+            }
+        }
+    }
+
+    /**
+     * 다중 항목 일괄 삭제 로직
+     * 폴더와 기기들을 일괄 삭제시킵니다. 대상 폴더는 하위 구조까지 재귀적으로 삭제됩니다.
+     *
+     * @param userId  : 삭제를 요청하는 유저 ID
+     * @param request : 삭제 항목들의 리스트
+     * @since : 2026.04.09
+     * @author : 최준혁
+     */
+    @Transactional
+    public void bulkDelete(Long userId, BulkDeleteRequest request) {
+        List<Long> folderIds = request.getFolderIds();
+        List<Long> deviceIds = request.getDeviceIds();
+
+        boolean isFolderIdsEmpty = (folderIds == null || folderIds.isEmpty());
+        boolean isDeviceIdsEmpty = (deviceIds == null || deviceIds.isEmpty());
+
+        if (isFolderIdsEmpty && isDeviceIdsEmpty) {
+            throw new CustomException(ErrorCode.BULK_ACTION_EMPTY_SELECTION);
+        }
+
+        // 1. 기기 삭제 로직
+        if (!isDeviceIdsEmpty) {
+            List<Device> devices = deviceRepository.findAllById(deviceIds);
+            for (Device device : devices) {
+                if (!device.getUserId().equals(userId)) {
+                    throw new CustomException(ErrorCode.BULK_ACTION_ACCESS_DENIED);
+                }
+            }
+            deviceRepository.deleteAll(devices);
+        }
+
+        // 2. 폴더 하위 연쇄 삭제 로직
+        if (!isFolderIdsEmpty) {
+            List<Folder> folders = folderRepository.findAllById(folderIds);
+            
+            // 삭제 전 모든 폴더의 소유권 먼저 검증 (도중 실패하여 DB 정합성 꺾임 방지)
+            for (Folder folder : folders) {
+                if (!folder.getUserId().equals(userId)) {
+                    throw new CustomException(ErrorCode.BULK_ACTION_ACCESS_DENIED);
+                }
+            }
+
+            // 소유권 통과 시 개별 폴더에 대해 DFS 하위 연쇄 삭제 적용
+            for (Folder folder : folders) {
+                if (folderRepository.existsById(folder.getFolderId())) {
+                    deleteSubFoldersAndDevicesRecursively(folder.getFolderId());
+                    folderRepository.delete(folder);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## 📌 개요
#### 아이템 목록에서 다중 선택 후 폴더 및 기기 이동 혹은 폴더 및 기기 삭제 API 구현 완료



## 🛠️ 작업 내용
- 다중 기기/폴더 이동(bulk-move) api 구현 완료
- 다중 기기/폴더 삭제(bulk-delete) api 구현 완료
- bulk-delete 시 하위 파일 및 폴더 Cascade 삭제 여부 테스트 완료



## ✅ 체크리스트
- [X] 코드 컨벤션을 준수했나요?
- [X] 테스트를 완료했나요?
- [X] 불필요한 주석을 제거했나요?

## 📸 스크린샷 (선택)
<img width="1043" height="486" alt="image" src="https://github.com/user-attachments/assets/f95c6b27-2327-4956-b75d-5b81e8f49d62" />
<img width="706" height="596" alt="image" src="https://github.com/user-attachments/assets/7ac38554-3737-46d4-b339-043de840eff6" />
<img width="756" height="519" alt="image" src="https://github.com/user-attachments/assets/93c2bcf8-903a-400e-813f-f49a190903f5" />
<img width="734" height="91" alt="image" src="https://github.com/user-attachments/assets/d379b174-7b0e-4e6c-b01e-ffceb19eed0f" />
<img width="616" height="129" alt="image" src="https://github.com/user-attachments/assets/c4d0522f-9bbf-4160-9c4f-445783a74dc6" />
