### PR TITLE
[FEAT] 아이템 검색 api 구현

### DIFF
--- a/src/main/java/com/After_Buy/DeviceService/controller/SearchController.java
+++ b/src/main/java/com/After_Buy/DeviceService/controller/SearchController.java
@@ -1,0 +1,64 @@
+package com.After_Buy.DeviceService.controller;
+
+import com.After_Buy.DeviceService.dto.response.ApiResponse;
+import com.After_Buy.DeviceService.dto.response.SearchResponse;
+import com.After_Buy.DeviceService.security.UserPrincipal;
+import com.After_Buy.DeviceService.service.FolderService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 통합 검색 컨트롤러
+ * 폴더명, 상품명, 브랜드를 대상으로 하는 통합 검색 API를 제공합니다.
+ * Base URL: /api/devices
+ * 포트: 8082
+ * 모든 엔드포인트는 JWT Bearer 토큰 인증 필수입니다.
+ *
+ * @since : 2026.04.10
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/devices")
+@RequiredArgsConstructor
+@Tag(name = "Search", description = "폴더 및 기기 통합 검색 API")
+public class SearchController {
+
+    private final FolderService folderService;
+
+    /**
+     * 폴더/기기 통합 검색 API
+     * folder_name, product_name, brand를 대상으로 검색어가 포함된 항목을 반환합니다.
+     * 검색 결과가 없으면 빈 배열([])을 반환합니다.
+     *
+     * @param userPrincipal : 인증된 사용자
+     * @param q             : 검색어 (빈 문자열이면 빈 결과 반환)
+     * @return : 200 OK + { folders: [...], devices: [...] }
+     * @since : 2026.04.10
+     * @author : 최준혁
+     */
+    @Operation(
+        summary = "폴더/기기 통합 검색",
+        description = "검색어로 폴더명·상품명·브랜드를 검색합니다. 결과 없을 시 빈 배열 반환."
+    )
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<SearchResponse>> search(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestParam(name = "q", required = false, defaultValue = "") String q) {
+
+        log.info("통합 검색 요청: userId={}, keyword={}", userPrincipal.getUserId(), q);
+
+        SearchResponse result = folderService.search(userPrincipal.getUserId(), q);
+
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+}

--- a/src/main/java/com/After_Buy/DeviceService/dto/response/SearchDeviceResultDto.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/response/SearchDeviceResultDto.java
@@ -1,0 +1,43 @@
+package com.After_Buy.DeviceService.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+/**
+ * 통합 검색 결과 - 기기 항목 DTO
+ * GET /api/devices/search 응답 내 devices 배열의 각 항목을 담는 DTO입니다.
+ * 미분류 기기(folder_id = null)인 경우 folderName도 null로 반환합니다.
+ *
+ * @since : 2026.04.10
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class SearchDeviceResultDto {
+
+    /** 기기 고유 ID */
+    private Long deviceId;
+
+    /** 상품명 */
+    private String productName;
+
+    /** 브랜드명 */
+    private String brand;
+
+    /** 보증 만료일 */
+    private LocalDate warrantyExpiryDate;
+
+    /** 소속 폴더 ID (null = 미분류) */
+    private Long folderId;
+
+    /** 소속 폴더명 (null = 미분류) */
+    private String folderName;
+}

--- a/src/main/java/com/After_Buy/DeviceService/dto/response/SearchFolderResultDto.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/response/SearchFolderResultDto.java
@@ -1,0 +1,31 @@
+package com.After_Buy.DeviceService.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 통합 검색 결과 - 폴더 항목 DTO
+ * GET /api/devices/search 응답 내 folders 배열의 각 항목을 담는 DTO입니다.
+ *
+ * @since : 2026.04.10
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class SearchFolderResultDto {
+
+    /** 폴더 고유 ID */
+    private Long folderId;
+
+    /** 폴더명 */
+    private String folderName;
+
+    /** 검색 매칭된 필드명 (folder_name 고정) */
+    private String matchField;
+}

--- a/src/main/java/com/After_Buy/DeviceService/dto/response/SearchResponse.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/response/SearchResponse.java
@@ -1,0 +1,31 @@
+package com.After_Buy.DeviceService.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 통합 검색 결과 응답 DTO
+ * GET /api/devices/search 응답 data 필드를 담는 DTO입니다.
+ * 검색 결과가 없을 경우 각 리스트는 빈 배열([])로 반환합니다.
+ *
+ * @since : 2026.04.10
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class SearchResponse {
+
+    /** 폴더 검색 결과 목록 (없을 경우 빈 배열) */
+    private List<SearchFolderResultDto> folders;
+
+    /** 기기 검색 결과 목록 (없을 경우 빈 배열) */
+    private List<SearchDeviceResultDto> devices;
+}

--- a/src/main/java/com/After_Buy/DeviceService/repository/DeviceRepository.java
+++ b/src/main/java/com/After_Buy/DeviceService/repository/DeviceRepository.java
@@ -55,4 +55,18 @@ public interface DeviceRepository extends JpaRepository<Device, Long> {
     @org.springframework.data.jpa.repository.Modifying
     @org.springframework.data.jpa.repository.Query("DELETE FROM Device d WHERE d.folderId = :folderId")
     void deleteByFolderId(@org.springframework.data.repository.query.Param("folderId") Long folderId);
+
+    /**
+     * 상품명 또는 브랜드 키워드 부분 검색 (통합 검색용)
+     * 사용자 소유 기기 중 productName 또는 brand에 keyword가 포함된 기기를 반환합니다.
+     * JPQL LOWER()로 대소문자 무시 검색을 수행합니다.
+     *
+     * @param userId  : 소유자 사용자 ID
+     * @param keyword : 검색 키워드
+     * @return : 매칭된 기기 목록
+     */
+    @Query("SELECT d FROM Device d WHERE d.userId = :userId " +
+           "AND (LOWER(d.productName) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+           "OR LOWER(d.brand) LIKE LOWER(CONCAT('%', :keyword, '%')))")
+    List<Device> searchByUserIdAndKeyword(@Param("userId") Long userId, @Param("keyword") String keyword);
 }

--- a/src/main/java/com/After_Buy/DeviceService/repository/FolderRepository.java
+++ b/src/main/java/com/After_Buy/DeviceService/repository/FolderRepository.java
@@ -76,5 +76,15 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 	 */
 	@Query("SELECT f.folderId FROM Folder f WHERE f.parentFolderId = :parentFolderId")
 	List<Long> findFolderIdsByParentFolderId(@Param("parentFolderId") Long parentFolderId);
+
+	/**
+	 * 폴더명 키워드 부분 검색 (통합 검색용)
+	 * 사용자 소유 폴더 중 folderName에 keyword가 포함된 폴더를 반환합니다.
+	 *
+	 * @param userId  : 소유자 사용자 ID
+	 * @param keyword : 검색 키워드
+	 * @return : 매칭된 폴더 목록
+	 */
+	List<Folder> findByUserIdAndFolderNameContainingIgnoreCase(Long userId, String keyword);
 }
 

--- a/src/main/java/com/After_Buy/DeviceService/service/FolderService.java
+++ b/src/main/java/com/After_Buy/DeviceService/service/FolderService.java
@@ -22,6 +22,9 @@ import com.After_Buy.DeviceService.dto.request.FolderCreateRequest;
 import com.After_Buy.DeviceService.dto.request.FolderUpdateNameRequest;
 import com.After_Buy.DeviceService.dto.request.BulkMoveRequest;
 import com.After_Buy.DeviceService.dto.request.BulkDeleteRequest;
+import com.After_Buy.DeviceService.dto.response.SearchResponse;
+import com.After_Buy.DeviceService.dto.response.SearchFolderResultDto;
+import com.After_Buy.DeviceService.dto.response.SearchDeviceResultDto;
 import com.After_Buy.DeviceService.entity.Folder;
 import com.After_Buy.DeviceService.exception.CustomException;
 import com.After_Buy.DeviceService.exception.ErrorCode;
@@ -325,9 +328,54 @@ public class FolderService {
             }
         }
     }
+
+    /**
+     * 폴더 및 기기 통합 검색
+     * 검색어(keyword)로 폴더명, 상품명, 브랜드를 부분 문자열(LIKE) 방식으로 검색합니다.
+     * 검색어가 비어있으면 빈 결과를 반환합니다.
+     *
+     * @param userId  : 조회를 요청하는 사용자 ID
+     * @param keyword : 검색어 (빈 문자열이면 빈 결과 반환)
+     * @return : 폴더 검색 결과 + 기기 검색 결과를 담은 SearchResponse
+     * @since : 2026.04.10
+     * @author : 최준혁
+     */
+    @Transactional(readOnly = true)
+    public SearchResponse search(Long userId, String keyword) {
+
+        /* 검색어가 null이거나 공백인 경우 빈 결과 반환 (방안 B 적용) */
+        if (keyword == null || keyword.trim().isEmpty()) {
+            return new SearchResponse(new ArrayList<>(), new ArrayList<>());
+        }
+
+        /* 1. 폴더명 검색 (대소문자 무시) */
+        List<Folder> matchedFolders = folderRepository.findByUserIdAndFolderNameContainingIgnoreCase(userId, keyword);
+        List<SearchFolderResultDto> folderResults = matchedFolders.stream()
+                .map(f -> new SearchFolderResultDto(f.getFolderId(), f.getFolderName(), "folder_name"))
+                .collect(Collectors.toList());
+
+        /* 2. 기기 상품명/브랜드 검색 */
+        List<Device> matchedDevices = deviceRepository.searchByUserIdAndKeyword(userId, keyword);
+        List<SearchDeviceResultDto> deviceResults = matchedDevices.stream()
+                .map(d -> {
+                    /* 미분류(folder_id = null)인 경우 folderName도 null 반환 */
+                    String folderName = null;
+                    if (d.getFolderId() != null) {
+                        folderName = folderRepository.findById(d.getFolderId())
+                                .map(Folder::getFolderName)
+                                .orElse(null);
+                    }
+                    return new SearchDeviceResultDto(
+                            d.getDeviceId(),
+                            d.getProductName(),
+                            d.getBrand(),
+                            d.getWarrantyExpiryDate(),
+                            d.getFolderId(),
+                            folderName
+                    );
+                })
+                .collect(Collectors.toList());
+
+        return new SearchResponse(folderResults, deviceResults);
+    }
 }
-
-
-
-
-


### PR DESCRIPTION
## 📌 개요
#### 아이템/폴더 공용 검색 API 구현



## 🛠️ 작업 내용
- 아이템 검색 결과와 폴더 검색결과를 합하여 반환하는 API 구현



## ✅ 체크리스트
- [X] 코드 컨벤션을 준수했나요?
- [X] 테스트를 완료했나요?
- [X] 불필요한 주석을 제거했나요?

## 📸 스크린샷 (선택)
<img width="787" height="801" alt="image" src="https://github.com/user-attachments/assets/ac86def5-afb9-458f-9bff-955b8c8f33fd" />
