### PR TITLE
[FEAT] 네이버 검색 API 결과 제미나이 파싱 구현

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -23,5 +23,5 @@ AWS_S3_BUCKET=your_s3_bucket_name_for_receipts_and_devices
 NAVER_CLIENT_ID=your_naver_openapi_client_id
 NAVER_CLIENT_SECRET=your_naver_openapi_client_secret
 
-# External API: Google Gemini (네이버 쇼핑 결과 정제용)
-GEMINI_API_KEY=your_gemini_api_key
+# External API: Google Cloud Vertex AI (네이버 쇼핑 결과 정제용)
+VERTEX_API_KEY=your_vertex_api_key

--- a/.env_example
+++ b/.env_example
@@ -22,3 +22,6 @@ AWS_S3_BUCKET=your_s3_bucket_name_for_receipts_and_devices
 # External API: Naver Shopping (기기 검색용)
 NAVER_CLIENT_ID=your_naver_openapi_client_id
 NAVER_CLIENT_SECRET=your_naver_openapi_client_secret
+
+# External API: Google Gemini (네이버 쇼핑 결과 정제용)
+GEMINI_API_KEY=your_gemini_api_key

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	// API 명세서 포맷 자동 생성 및 Swagger UI 제공
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.16'
-	
+
+
+
 	// AWS 연동 라이브러리 버전 통합 관리 (BOM) - AWS 접속 정보 미비로 인한 에러 방지를 위해 임시 주석 처리
 	// implementation platform('io.awspring.cloud:spring-cloud-aws-dependencies:3.1.1')
 	// 기기 이미지 및 영수증 클라우드 업로드 전용 (S3)

--- a/src/main/java/com/After_Buy/DeviceService/service/GeminiParsingService.java
+++ b/src/main/java/com/After_Buy/DeviceService/service/GeminiParsingService.java
@@ -14,6 +14,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
+
 /**
  * Gemini API 연동을 통한 네이버 쇼핑 결과 정제 서비스
  * 네이버 쇼핑 API 원본 응답(제품명, 브랜드)을 Gemini LLM에게 전달하여
@@ -32,19 +33,18 @@ public class GeminiParsingService {
     private final String apiKey;
     private final ObjectMapper objectMapper;
 
-    /* Gemini 2.5 Flash Lite 모델 REST API 엔드포인트
-     * - 공식 문서 기준 현재 사용 가능한 가장 빠르고 저렴한 안정(Stable) 모델
-     * - 단순 분류/정제 태스크에 최적, 처리량이 높아 503 발생 가능성이 낮음 */
-    private static final String GEMINI_BASE_URL = "https://generativelanguage.googleapis.com";
-    private static final String GEMINI_PATH = "/v1beta/models/gemini-2.5-flash-lite:generateContent";
+    /* Google Cloud Vertex AI Gemini 엔드포인트 */
+    private static final String VERTEX_GEMINI_BASE_URL = "https://aiplatform.googleapis.com";
+    private static final String VERTEX_GEMINI_PATH = "/v1/publishers/google/models/gemini-2.5-flash-lite:generateContent";
 
     public GeminiParsingService(
             WebClient.Builder webClientBuilder,
-            @Value("${gemini.api-key}") String apiKey) {
-        this.webClient = webClientBuilder.baseUrl(GEMINI_BASE_URL).build();
+            @Value("${vertex.api-key}") String apiKey) {
+        this.webClient = webClientBuilder.baseUrl(VERTEX_GEMINI_BASE_URL).build();
         this.apiKey = apiKey;
         this.objectMapper = new ObjectMapper();
     }
+
 
     /**
      * 네이버 쇼핑 검색 결과 제품명·브랜드 정제 메서드
@@ -65,7 +65,7 @@ public class GeminiParsingService {
 
             String responseBody = webClient.post()
                     .uri(uriBuilder -> uriBuilder
-                            .path(GEMINI_PATH)
+                            .path(VERTEX_GEMINI_PATH)
                             .queryParam("key", apiKey)
                             .build())
                     .contentType(MediaType.APPLICATION_JSON)
@@ -159,10 +159,15 @@ public class GeminiParsingService {
             Map<String, Object> requestMap = Map.of(
                     /* 역할/규칙 모듈: 시스템 인스트럭션으로 분리 */
                     "system_instruction", Map.of(
+                            "role", "system",
                             "parts", List.of(Map.of("text", buildSystemInstruction()))),
                     /* 데이터 모듈: 유저 프롬프트는 데이터만 */
                     "contents", List.of(
-                            Map.of("parts", List.of(Map.of("text", userPrompt)))),
+                            Map.of(
+                                    "role", "user",
+                                    "parts", List.of(Map.of("text", userPrompt))
+                            )
+                    ),
                     /* JSON 응답 강제: 프롬프트에 'JSON으로 답해줘' 구문 보담 안해도 됨 */
                     "generationConfig", Map.of(
                             "response_mime_type", "application/json")

--- a/src/main/java/com/After_Buy/DeviceService/service/GeminiParsingService.java
+++ b/src/main/java/com/After_Buy/DeviceService/service/GeminiParsingService.java
@@ -32,9 +32,11 @@ public class GeminiParsingService {
     private final String apiKey;
     private final ObjectMapper objectMapper;
 
-    /* Gemini 2.5 Flash 모델 REST API 엔드포인트 */
+    /* Gemini 2.5 Flash Lite 모델 REST API 엔드포인트
+     * - 공식 문서 기준 현재 사용 가능한 가장 빠르고 저렴한 안정(Stable) 모델
+     * - 단순 분류/정제 태스크에 최적, 처리량이 높아 503 발생 가능성이 낮음 */
     private static final String GEMINI_BASE_URL = "https://generativelanguage.googleapis.com";
-    private static final String GEMINI_PATH = "/v1beta/models/gemini-2.5-flash:generateContent";
+    private static final String GEMINI_PATH = "/v1beta/models/gemini-2.5-flash-lite:generateContent";
 
     public GeminiParsingService(
             WebClient.Builder webClientBuilder,
@@ -58,8 +60,8 @@ public class GeminiParsingService {
      */
     public String[] refine(String rawProductName, String rawBrand) {
         try {
-            String prompt = buildPrompt(rawProductName, rawBrand);
-            String requestBody = buildRequestBody(prompt);
+            String userPrompt = buildUserPrompt(rawProductName, rawBrand);
+            String requestBody = buildRequestBody(userPrompt);
 
             String responseBody = webClient.post()
                     .uri(uriBuilder -> uriBuilder
@@ -106,50 +108,65 @@ public class GeminiParsingService {
     }
 
     /**
-     * Gemini 프롬프트 생성 메서드
-     * 전자기기 여부를 먼저 판별하고, 전자기기일 때만 제품명·브랜드를 정제합니다.
-     * 케이스, 필름, 충전기 등 액세서리로 판단되면 null을 반환하도록 지시합니다.
+     * 시스템 인스트럭션 생성 메서드 (Gemini 역할/규칙 모듈)
+     * 프롬프트에서 분리하여 토큰 절감. 각 호출마다 반복 전송하지 않고 요청 구조에서 도구 역할을 담습니다.
+     * 전자기기 판별 기준과 정제 규칙을 포함합니다.
      *
-     * @param rawProductName : 원본 제품명
-     * @param rawBrand       : 원본 브랜드명
-     * @return : Gemini에 전달할 완성된 프롬프트 문자열
+     * @return : Gemini system_instruction 텍스트
      * @since : 2026.04.11
      * @author : 최준혁
      */
-    private String buildPrompt(String rawProductName, String rawBrand) {
-        return "아래 네이버 쇼핑 검색 결과가 \"\uc804자기기\"인지 먼저 판별해줘.\n\n" +
-                "판별 기준:\n" +
-                "- 전자기기(O): 스마트폰, 노트북, 태블릿, 이어폰, 헤드폰, 스마트워치, TV, 모니터, 카메라, 게임기, 전자체 등 가전제품 본체\n" +
-                "- 전자기기(아님): 케이스, 보호필름, 충전기, 케이블, 거치대, 가방, 파우치, 액세서리, 스티커, 청소용품 등\n\n" +
-                "전자기기가 아닌 경우 (케이스, 액세서리 등):\n" +
-                "{\"product_name\": null, \"brand\": null}\n\n" +
-                "전자기기인 경우 아래 규칙에 따라 정제해줘:\n" +
-                "1. 제품명에서 모델 코드(예: SM-S928N, MKGP3KH/A 등 알파벳+숫자 조합)는 제거\n" +
-                "2. 256GB, 512GB, 1TB 등 저장 용량 정보는 반드시 유지\n" +
-                "3. '정품', '공식', '자급제' 등 판매 수식어는 제거\n" +
-                "4. 제품명 앞에 브랜드명이 중복되어 있으면 제거\n" +
-                "5. 브랜드는 대표 브랜드명으로 정리 ('삼성전자' → '삼성', 'LG전자' → 'LG')\n\n" +
-                "반드시 순수 JSON만 응답 (설명, 마크다운 코드블록 없이):\n" +
-                "{\"product_name\": \"정제된 제품명\", \"brand\": \"정제된 브랜드\"}\n\n" +
-                "입력:\n" +
-                "제품명: " + rawProductName + "\n" +
-                "브랜드: " + rawBrand;
+    private String buildSystemInstruction() {
+        return "You are a Korean e-commerce product classifier. " +
+               "Given a product name and brand from Naver Shopping:\n" +
+               "1. Determine if it is a consumer ELECTRONICS DEVICE " +
+               "(smartphone, laptop, tablet, earphones, headphones, smartwatch, TV, monitor, camera, game console). " +
+               "NOT a case, film, charger, cable, stand, bag, or accessory.\n" +
+               "2. If NOT a device: output {\"product_name\":null,\"brand\":null}\n" +
+               "3. If a device: remove model codes (e.g. SM-S928N, MKGP3KH/A), " +
+               "remove storage capacity (256GB, 512GB, 1TB etc), remove sales words (정품/자급제/공식), " +
+               "remove brand prefix duplication, normalize brand (삼성전자→삼성, LG전자→LG).";
     }
 
     /**
-     * Gemini REST API 요청 본문(JSON) 생성 메서드
+     * 유저 프롬프트 생성 메서드 (모듈식 - 데이터만 전달)
+     * 시스템 인스트럭션에서 규칙을 정의하고, 이 프롬프트에는 비교 데이터만 담습니다.
+     * 토큰 사용량을 최소화합니다.
      *
-     * @param prompt : Gemini에게 전달할 프롬프트
+     * @param rawProductName : 원본 제품명
+     * @param rawBrand       : 원본 브랜드명
+     * @return : 데이터만 담은 최소 프롬프트
+     * @since : 2026.04.11
+     * @author : 최준혁
+     */
+    private String buildUserPrompt(String rawProductName, String rawBrand) {
+        return "Product: " + rawProductName + "\nBrand: " + rawBrand;
+    }
+
+    /**
+     * Gemini REST API 요청 본문(JSON) 생성 메서드 (모듈식 구조 적용)
+     * system_instruction에 역할/규칙을, contents에 데이터만 담아 토큰을 절감합니다.
+     * generationConfig.response_mime_type으로 JSON 응답을 강제하여
+     * 프롬프트에 'JSON으로 답해줘' 문구를 넣을 필요가 없습니다.
+     *
+     * @param userPrompt : 데이터만 담은 유저 프롬프트
      * @return : Gemini API 요청 JSON 문자열
      * @since : 2026.04.11
      * @author : 최준혁
      */
-    private String buildRequestBody(String prompt) {
+    private String buildRequestBody(String userPrompt) {
         try {
             Map<String, Object> requestMap = Map.of(
+                    /* 역할/규칙 모듈: 시스템 인스트럭션으로 분리 */
+                    "system_instruction", Map.of(
+                            "parts", List.of(Map.of("text", buildSystemInstruction()))),
+                    /* 데이터 모듈: 유저 프롬프트는 데이터만 */
                     "contents", List.of(
-                            Map.of("parts", List.of(
-                                    Map.of("text", prompt)))));
+                            Map.of("parts", List.of(Map.of("text", userPrompt)))),
+                    /* JSON 응답 강제: 프롬프트에 'JSON으로 답해줘' 구문 보담 안해도 됨 */
+                    "generationConfig", Map.of(
+                            "response_mime_type", "application/json")
+            );
             return objectMapper.writeValueAsString(requestMap);
         } catch (Exception e) {
             throw new RuntimeException("Gemini 요청 본문 생성 실패", e);

--- a/src/main/java/com/After_Buy/DeviceService/service/GeminiParsingService.java
+++ b/src/main/java/com/After_Buy/DeviceService/service/GeminiParsingService.java
@@ -80,8 +80,6 @@ public class GeminiParsingService {
                                             new RuntimeException("Gemini HTTP 오류 " + clientResponse.statusCode().value()
                                                     + ": " + errorBody))))
                     .bodyToMono(String.class)
-                    /* 10초 타임아웃: Gemini 응답이 지연될 경우 빠르게 포기하고 fallback 처리 */
-                    .timeout(Duration.ofSeconds(10))
                     /*
                      * 503(Service Unavailable) 발생 시 최대 2회 재시도 (Exponential Backoff)
                      * - 1차 재시도: 1초 후
@@ -91,8 +89,8 @@ public class GeminiParsingService {
                     .retryWhen(Retry.backoff(2, Duration.ofSeconds(1))
                             .filter(throwable -> throwable instanceof WebClientResponseException.ServiceUnavailable
                                     || (throwable instanceof RuntimeException
-                                        && throwable.getMessage() != null
-                                        && throwable.getMessage().contains("503")))
+                                            && throwable.getMessage() != null
+                                            && throwable.getMessage().contains("503")))
                             .doBeforeRetry(signal -> log.warn(
                                     "[GeminiParsingService] Gemini 503 재시도 중... ({}/2회)",
                                     signal.totalRetries() + 1)))
@@ -120,22 +118,22 @@ public class GeminiParsingService {
      */
     private String buildPrompt(String rawProductName, String rawBrand) {
         return "아래 네이버 쇼핑 검색 결과가 \"\uc804자기기\"인지 먼저 판별해줘.\n\n" +
-               "판별 기준:\n" +
-               "- 전자기기(O): 스마트폰, 노트북, 태블릿, 이어폰, 헤드폰, 스마트워치, TV, 모니터, 카메라, 게임기, 전자체 등 가전제품 본체\n" +
-               "- 전자기기(아님): 케이스, 보호필름, 충전기, 케이블, 거치대, 가방, 파우치, 액세서리, 스티커, 청소용품 등\n\n" +
-               "전자기기가 아닌 경우 (케이스, 액세서리 등):\n" +
-               "{\"product_name\": null, \"brand\": null}\n\n" +
-               "전자기기인 경우 아래 규칙에 따라 정제해줘:\n" +
-               "1. 제품명에서 모델 코드(예: SM-S928N, MKGP3KH/A 등 알파벳+숫자 조합)는 제거\n" +
-               "2. 256GB, 512GB, 1TB 등 저장 용량 정보는 반드시 유지\n" +
-               "3. '정품', '공식', '자급제' 등 판매 수식어는 제거\n" +
-               "4. 제품명 앞에 브랜드명이 중복되어 있으면 제거\n" +
-               "5. 브랜드는 대표 브랜드명으로 정리 ('삼성전자' → '삼성', 'LG전자' → 'LG')\n\n" +
-               "반드시 순수 JSON만 응답 (설명, 마크다운 코드블록 없이):\n" +
-               "{\"product_name\": \"정제된 제품명\", \"brand\": \"정제된 브랜드\"}\n\n" +
-               "입력:\n" +
-               "제품명: " + rawProductName + "\n" +
-               "브랜드: " + rawBrand;
+                "판별 기준:\n" +
+                "- 전자기기(O): 스마트폰, 노트북, 태블릿, 이어폰, 헤드폰, 스마트워치, TV, 모니터, 카메라, 게임기, 전자체 등 가전제품 본체\n" +
+                "- 전자기기(아님): 케이스, 보호필름, 충전기, 케이블, 거치대, 가방, 파우치, 액세서리, 스티커, 청소용품 등\n\n" +
+                "전자기기가 아닌 경우 (케이스, 액세서리 등):\n" +
+                "{\"product_name\": null, \"brand\": null}\n\n" +
+                "전자기기인 경우 아래 규칙에 따라 정제해줘:\n" +
+                "1. 제품명에서 모델 코드(예: SM-S928N, MKGP3KH/A 등 알파벳+숫자 조합)는 제거\n" +
+                "2. 256GB, 512GB, 1TB 등 저장 용량 정보는 반드시 유지\n" +
+                "3. '정품', '공식', '자급제' 등 판매 수식어는 제거\n" +
+                "4. 제품명 앞에 브랜드명이 중복되어 있으면 제거\n" +
+                "5. 브랜드는 대표 브랜드명으로 정리 ('삼성전자' → '삼성', 'LG전자' → 'LG')\n\n" +
+                "반드시 순수 JSON만 응답 (설명, 마크다운 코드블록 없이):\n" +
+                "{\"product_name\": \"정제된 제품명\", \"brand\": \"정제된 브랜드\"}\n\n" +
+                "입력:\n" +
+                "제품명: " + rawProductName + "\n" +
+                "브랜드: " + rawBrand;
     }
 
     /**

--- a/src/main/java/com/After_Buy/DeviceService/service/GeminiParsingService.java
+++ b/src/main/java/com/After_Buy/DeviceService/service/GeminiParsingService.java
@@ -1,0 +1,180 @@
+package com.After_Buy.DeviceService.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Gemini API 연동을 통한 네이버 쇼핑 결과 정제 서비스
+ * 네이버 쇼핑 API 원본 응답(제품명, 브랜드)을 Gemini LLM에게 전달하여
+ * 불필요한 모델 코드 제거, 브랜드 정규화 등을 수행합니다.
+ * Gemini 호출 실패 시 원본 값을 그대로 반환하여 서비스 장애를 방지합니다.
+ *
+ * @since : 2026.04.11
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Slf4j
+@Service
+public class GeminiParsingService {
+
+    private final WebClient webClient;
+    private final String apiKey;
+    private final ObjectMapper objectMapper;
+
+    /* Gemini 2.5 Flash 모델 REST API 엔드포인트 */
+    private static final String GEMINI_BASE_URL = "https://generativelanguage.googleapis.com";
+    private static final String GEMINI_PATH = "/v1beta/models/gemini-2.5-flash:generateContent";
+
+    public GeminiParsingService(
+            WebClient.Builder webClientBuilder,
+            @Value("${gemini.api-key}") String apiKey) {
+        this.webClient = webClientBuilder.baseUrl(GEMINI_BASE_URL).build();
+        this.apiKey = apiKey;
+        this.objectMapper = new ObjectMapper();
+    }
+
+    /**
+     * 네이버 쇼핑 검색 결과 제품명·브랜드 정제 메서드
+     * Gemini API를 통해 제품명과 브랜드를 정제하고 반환합니다.
+     * Gemini 장애/파싱 실패 시 원본 값을 그대로 반환합니다.
+     * 모델명(modelName)은 절대 수정하지 않으며, 이 메서드에서는 받지도 않습니다.
+     *
+     * @param rawProductName : 네이버 쇼핑 원본 제품명 (HTML 태그 제거 후)
+     * @param rawBrand       : 네이버 쇼핑 원본 브랜드명
+     * @return : 정제된 제품명과 브랜드를 담은 배열 [refinedProductName, refinedBrand]
+     * @since : 2026.04.11
+     * @author : 최준혁
+     */
+    public String[] refine(String rawProductName, String rawBrand) {
+        try {
+            String prompt = buildPrompt(rawProductName, rawBrand);
+            String requestBody = buildRequestBody(prompt);
+
+            String responseBody = webClient.post()
+                    .uri(uriBuilder -> uriBuilder
+                            .path(GEMINI_PATH)
+                            .queryParam("key", apiKey)
+                            .build())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(requestBody)
+                    .retrieve()
+                    /* 4xx/5xx 에러 발생 시 응답 본문을 로그로 남겨 진짜 원인 파악 */
+                    .onStatus(
+                            status -> status.is4xxClientError() || status.is5xxServerError(),
+                            clientResponse -> clientResponse.bodyToMono(String.class)
+                                    .doOnNext(errorBody -> log.error(
+                                            "[GeminiParsingService] Gemini API 오류 응답 (HTTP {}): {}",
+                                            clientResponse.statusCode().value(), errorBody))
+                                    .flatMap(errorBody -> reactor.core.publisher.Mono.error(
+                                            new RuntimeException("Gemini HTTP 오류 " + clientResponse.statusCode().value()
+                                                    + ": " + errorBody))))
+                    .bodyToMono(String.class)
+                    .block();
+
+            return parseGeminiResponse(responseBody, rawProductName, rawBrand);
+
+        } catch (Exception e) {
+            /* Gemini 호출 실패 시 서비스 중단 없이 원본 값 그대로 반환 */
+            log.warn("[GeminiParsingService] Gemini 정제 호출 실패, 원본 값 사용. 사유: {}", e.getMessage());
+            return new String[] { rawProductName, rawBrand };
+        }
+    }
+
+    /**
+     * Gemini 프롬프트 생성 메서드
+     * 제품명에서 모델 코드 제거, 용량 정보(256GB 등) 유지, 브랜드 정규화 지시를 담습니다.
+     *
+     * @param rawProductName : 원본 제품명
+     * @param rawBrand       : 원본 브랜드명
+     * @return : Gemini에 전달할 완성된 프롬프트 문자열
+     * @since : 2026.04.11
+     * @author : 최준혁
+     */
+    private String buildPrompt(String rawProductName, String rawBrand) {
+        return "다음 네이버 쇼핑 검색 결과의 제품명과 브랜드를 아래 규칙에 따라 정제해줘.\n\n" +
+                "규칙:\n" +
+                "1. 제품명에서 모델 코드(예: SM-S928N, MKGP3KH/A, MU7N3LL/A 등 알파벳+숫자 조합)는 제거\n" +
+                "2. 256GB, 512GB, 1TB 등 저장 용량 정보는 반드시 유지\n" +
+                "3. '정품', '공식', '자급제' 등 불필요한 판매 수식어는 제거\n" +
+                "4. 제품명 앞에 브랜드명이 중복되어 있으면 제거\n" +
+                "5. 브랜드는 대표 브랜드명으로 정리 (예: '삼성전자' → '삼성', 'LG전자' → 'LG')\n" +
+                "6. 반드시 아래 JSON 형식으로만 응답 (설명, 마크다운 코드블록 없이 순수 JSON만):\n" +
+                "{\"product_name\": \"정제된 제품명\", \"brand\": \"정제된 브랜드\"}\n\n" +
+                "입력:\n" +
+                "제품명: " + rawProductName + "\n" +
+                "브랜드: " + rawBrand;
+    }
+
+    /**
+     * Gemini REST API 요청 본문(JSON) 생성 메서드
+     *
+     * @param prompt : Gemini에게 전달할 프롬프트
+     * @return : Gemini API 요청 JSON 문자열
+     * @since : 2026.04.11
+     * @author : 최준혁
+     */
+    private String buildRequestBody(String prompt) {
+        try {
+            Map<String, Object> requestMap = Map.of(
+                    "contents", List.of(
+                            Map.of("parts", List.of(
+                                    Map.of("text", prompt)))));
+            return objectMapper.writeValueAsString(requestMap);
+        } catch (Exception e) {
+            throw new RuntimeException("Gemini 요청 본문 생성 실패", e);
+        }
+    }
+
+    /**
+     * Gemini 응답 파싱 메서드
+     * candidates[0].content.parts[0].text 에서 JSON을 추출하여 정제된 값을 반환합니다.
+     * 파싱 실패 시 원본 값을 반환합니다.
+     *
+     * @param responseBody   : Gemini API 원본 응답 JSON 문자열
+     * @param rawProductName : 파싱 실패 시 fallback으로 반환할 원본 제품명
+     * @param rawBrand       : 파싱 실패 시 fallback으로 반환할 원본 브랜드명
+     * @return : [정제된 제품명, 정제된 브랜드명]
+     * @since : 2026.04.11
+     * @author : 최준혁
+     */
+    private String[] parseGeminiResponse(String responseBody, String rawProductName, String rawBrand) {
+        try {
+            JsonNode root = objectMapper.readTree(responseBody);
+
+            /* Gemini 응답 구조: candidates[0].content.parts[0].text */
+            String text = root
+                    .path("candidates").get(0)
+                    .path("content")
+                    .path("parts").get(0)
+                    .path("text")
+                    .asText();
+
+            /* Gemini가 마크다운 코드블록을 포함할 수 있으므로 순수 JSON 부분만 추출 */
+            String cleanedText = text.trim();
+            if (cleanedText.startsWith("```")) {
+                cleanedText = cleanedText.replaceAll("```[a-z]*\\n?", "").replace("```", "").trim();
+            }
+
+            JsonNode parsedResult = objectMapper.readTree(cleanedText);
+            String refinedProductName = parsedResult.path("product_name").asText(rawProductName);
+            String refinedBrand = parsedResult.path("brand").asText(rawBrand);
+
+            log.info("[GeminiParsingService] 정제 완료 - 제품명: '{}' → '{}', 브랜드: '{}' → '{}'",
+                    rawProductName, refinedProductName, rawBrand, refinedBrand);
+
+            return new String[] { refinedProductName, refinedBrand };
+
+        } catch (Exception e) {
+            log.warn("[GeminiParsingService] Gemini 응답 파싱 실패, 원본 값 사용. 사유: {}", e.getMessage());
+            return new String[] { rawProductName, rawBrand };
+        }
+    }
+}

--- a/src/main/java/com/After_Buy/DeviceService/service/GeminiParsingService.java
+++ b/src/main/java/com/After_Buy/DeviceService/service/GeminiParsingService.java
@@ -7,7 +7,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.util.retry.Retry;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
@@ -77,6 +80,22 @@ public class GeminiParsingService {
                                             new RuntimeException("Gemini HTTP 오류 " + clientResponse.statusCode().value()
                                                     + ": " + errorBody))))
                     .bodyToMono(String.class)
+                    /* 10초 타임아웃: Gemini 응답이 지연될 경우 빠르게 포기하고 fallback 처리 */
+                    .timeout(Duration.ofSeconds(10))
+                    /*
+                     * 503(Service Unavailable) 발생 시 최대 2회 재시도 (Exponential Backoff)
+                     * - 1차 재시도: 1초 후
+                     * - 2차 재시도: 2초 후
+                     * - 429(Rate Limit)나 4xx는 재시도하지 않음 (의미 없음)
+                     */
+                    .retryWhen(Retry.backoff(2, Duration.ofSeconds(1))
+                            .filter(throwable -> throwable instanceof WebClientResponseException.ServiceUnavailable
+                                    || (throwable instanceof RuntimeException
+                                        && throwable.getMessage() != null
+                                        && throwable.getMessage().contains("503")))
+                            .doBeforeRetry(signal -> log.warn(
+                                    "[GeminiParsingService] Gemini 503 재시도 중... ({}/2회)",
+                                    signal.totalRetries() + 1)))
                     .block();
 
             return parseGeminiResponse(responseBody, rawProductName, rawBrand);
@@ -90,7 +109,8 @@ public class GeminiParsingService {
 
     /**
      * Gemini 프롬프트 생성 메서드
-     * 제품명에서 모델 코드 제거, 용량 정보(256GB 등) 유지, 브랜드 정규화 지시를 담습니다.
+     * 전자기기 여부를 먼저 판별하고, 전자기기일 때만 제품명·브랜드를 정제합니다.
+     * 케이스, 필름, 충전기 등 액세서리로 판단되면 null을 반환하도록 지시합니다.
      *
      * @param rawProductName : 원본 제품명
      * @param rawBrand       : 원본 브랜드명
@@ -99,18 +119,23 @@ public class GeminiParsingService {
      * @author : 최준혁
      */
     private String buildPrompt(String rawProductName, String rawBrand) {
-        return "다음 네이버 쇼핑 검색 결과의 제품명과 브랜드를 아래 규칙에 따라 정제해줘.\n\n" +
-                "규칙:\n" +
-                "1. 제품명에서 모델 코드(예: SM-S928N, MKGP3KH/A, MU7N3LL/A 등 알파벳+숫자 조합)는 제거\n" +
-                "2. 256GB, 512GB, 1TB 등 저장 용량 정보는 반드시 유지\n" +
-                "3. '정품', '공식', '자급제' 등 불필요한 판매 수식어는 제거\n" +
-                "4. 제품명 앞에 브랜드명이 중복되어 있으면 제거\n" +
-                "5. 브랜드는 대표 브랜드명으로 정리 (예: '삼성전자' → '삼성', 'LG전자' → 'LG')\n" +
-                "6. 반드시 아래 JSON 형식으로만 응답 (설명, 마크다운 코드블록 없이 순수 JSON만):\n" +
-                "{\"product_name\": \"정제된 제품명\", \"brand\": \"정제된 브랜드\"}\n\n" +
-                "입력:\n" +
-                "제품명: " + rawProductName + "\n" +
-                "브랜드: " + rawBrand;
+        return "아래 네이버 쇼핑 검색 결과가 \"\uc804자기기\"인지 먼저 판별해줘.\n\n" +
+               "판별 기준:\n" +
+               "- 전자기기(O): 스마트폰, 노트북, 태블릿, 이어폰, 헤드폰, 스마트워치, TV, 모니터, 카메라, 게임기, 전자체 등 가전제품 본체\n" +
+               "- 전자기기(아님): 케이스, 보호필름, 충전기, 케이블, 거치대, 가방, 파우치, 액세서리, 스티커, 청소용품 등\n\n" +
+               "전자기기가 아닌 경우 (케이스, 액세서리 등):\n" +
+               "{\"product_name\": null, \"brand\": null}\n\n" +
+               "전자기기인 경우 아래 규칙에 따라 정제해줘:\n" +
+               "1. 제품명에서 모델 코드(예: SM-S928N, MKGP3KH/A 등 알파벳+숫자 조합)는 제거\n" +
+               "2. 256GB, 512GB, 1TB 등 저장 용량 정보는 반드시 유지\n" +
+               "3. '정품', '공식', '자급제' 등 판매 수식어는 제거\n" +
+               "4. 제품명 앞에 브랜드명이 중복되어 있으면 제거\n" +
+               "5. 브랜드는 대표 브랜드명으로 정리 ('삼성전자' → '삼성', 'LG전자' → 'LG')\n\n" +
+               "반드시 순수 JSON만 응답 (설명, 마크다운 코드블록 없이):\n" +
+               "{\"product_name\": \"정제된 제품명\", \"brand\": \"정제된 브랜드\"}\n\n" +
+               "입력:\n" +
+               "제품명: " + rawProductName + "\n" +
+               "브랜드: " + rawBrand;
     }
 
     /**
@@ -136,12 +161,13 @@ public class GeminiParsingService {
     /**
      * Gemini 응답 파싱 메서드
      * candidates[0].content.parts[0].text 에서 JSON을 추출하여 정제된 값을 반환합니다.
+     * Gemini가 전자기기가 아님으로 판별(케이스 등)시 null을 반환합니다.
      * 파싱 실패 시 원본 값을 반환합니다.
      *
      * @param responseBody   : Gemini API 원본 응답 JSON 문자열
      * @param rawProductName : 파싱 실패 시 fallback으로 반환할 원본 제품명
      * @param rawBrand       : 파싱 실패 시 fallback으로 반환할 원본 브랜드명
-     * @return : [정제된 제품명, 정제된 브랜드명]
+     * @return : [정제된 제품명, 정제된 브랜드명] 또는 null (전자기기 아님으로 판단시)
      * @since : 2026.04.11
      * @author : 최준혁
      */
@@ -164,7 +190,15 @@ public class GeminiParsingService {
             }
 
             JsonNode parsedResult = objectMapper.readTree(cleanedText);
-            String refinedProductName = parsedResult.path("product_name").asText(rawProductName);
+
+            /* Gemini가 전자기기가 아님으로 판단한 경우: product_name이 null 또는 비어있음 */
+            JsonNode productNameNode = parsedResult.path("product_name");
+            if (productNameNode.isNull() || productNameNode.isMissingNode()) {
+                log.warn("[GeminiParsingService] 전자기기가 아님으로 판단 - 검색 실패 처리. 원본 제품명: '{}'", rawProductName);
+                return null;
+            }
+
+            String refinedProductName = productNameNode.asText(rawProductName);
             String refinedBrand = parsedResult.path("brand").asText(rawBrand);
 
             log.info("[GeminiParsingService] 정제 완료 - 제품명: '{}' → '{}', 브랜드: '{}' → '{}'",

--- a/src/main/java/com/After_Buy/DeviceService/service/NaverSearchService.java
+++ b/src/main/java/com/After_Buy/DeviceService/service/NaverSearchService.java
@@ -26,14 +26,17 @@ public class NaverSearchService {
     private final WebClient webClient;
     private final String clientId;
     private final String clientSecret;
+    private final GeminiParsingService geminiParsingService;
 
     public NaverSearchService(
             WebClient.Builder webClientBuilder,
             @Value("${naver.client-id}") String clientId,
-            @Value("${naver.client-secret}") String clientSecret) {
+            @Value("${naver.client-secret}") String clientSecret,
+            GeminiParsingService geminiParsingService) {
         this.webClient = webClientBuilder.baseUrl("https://openapi.naver.com/v1/search").build();
         this.clientId = clientId;
         this.clientSecret = clientSecret;
+        this.geminiParsingService = geminiParsingService;
     }
 
     /**
@@ -80,10 +83,25 @@ public class NaverSearchService {
             throw new CustomException(ErrorCode.SEARCH_NO_RESULT);
         }
 
+        // 브랜드 원본 추출 (brand 없으면 maker 사용)
+        String rawBrand = item.getBrand() != null && !item.getBrand().isEmpty()
+                ? item.getBrand()
+                : item.getMaker();
+
+        /*
+         * Gemini LLM으로 제품명·브랜드 정제 수행
+         * - 모델 코드 제거, 판매 수식어 제거, 브랜드 정규화 등
+         * - 저장 용량(256GB 등)은 유지
+         * - modelName은 이 단계에서 절대 수정하지 않음
+         */
+        String[] refined = geminiParsingService.refine(cleanTitle, rawBrand);
+        String refinedProductName = refined[0];
+        String refinedBrand = refined[1];
+
         return NaverProductDto.builder()
-                .productName(cleanTitle)
+                .productName(refinedProductName)
                 .modelName(modelName)
-                .brand(item.getBrand() != null && !item.getBrand().isEmpty() ? item.getBrand() : item.getMaker())
+                .brand(refinedBrand)
                 .imageUrl(item.getImage())
                 .productLinkUrl(item.getLink())
                 .build();

--- a/src/main/java/com/After_Buy/DeviceService/service/NaverSearchService.java
+++ b/src/main/java/com/After_Buy/DeviceService/service/NaverSearchService.java
@@ -93,8 +93,15 @@ public class NaverSearchService {
          * - 모델 코드 제거, 판매 수식어 제거, 브랜드 정규화 등
          * - 저장 용량(256GB 등)은 유지
          * - modelName은 이 단계에서 절대 수정하지 않음
+         * - Gemini가 전자기기가 아님으로 판단(케이스, 액세서리 등)하면 null 반환 → 검색 실패 처리
          */
         String[] refined = geminiParsingService.refine(cleanTitle, rawBrand);
+
+        if (refined == null) {
+            log.warn("[NaverSearchService] Gemini가 전자기기 아님으로 판별. 검색 결과 거부. (조회된 상품: {})", cleanTitle);
+            throw new CustomException(ErrorCode.SEARCH_NO_RESULT);
+        }
+
         String refinedProductName = refined[0];
         String refinedBrand = refined[1];
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -53,6 +53,6 @@ naver:
   client-id: ${NAVER_CLIENT_ID}
   client-secret: ${NAVER_CLIENT_SECRET}
 
-# Google Gemini API 연동 정보 (.env 매핑)
-gemini:
-  api-key: ${GEMINI_API_KEY}
+# Google Cloud Vertex AI Gemini 연동 설정 (.env 매핑)
+vertex:
+  api-key: ${VERTEX_API_KEY}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -52,3 +52,7 @@ jwt:
 naver:
   client-id: ${NAVER_CLIENT_ID}
   client-secret: ${NAVER_CLIENT_SECRET}
+
+# Google Gemini API 연동 정보 (.env 매핑)
+gemini:
+  api-key: ${GEMINI_API_KEY}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -26,3 +26,6 @@ internal:
 naver:
   client-id: "test-client-id"
   client-secret: "test-client-secret"
+
+vertex:
+  api-key: "test-vertex-api-key"


### PR DESCRIPTION
## 📌 개요
#### 네이버 검색 API 호출 결과에 제미나이 API를 도입하여 파싱 (제품명, 브랜드 정돈)



## 🛠️ 작업 내용
- 제미나이 키 발급
- 네이버 쇼핑 API 내 제미나이 API 호출
- 제미나이가 파싱한 응답 사용자에게 응답
- 제미나이 무응답시 기존 네이버 쇼핑 API 호출 결과 반환
- 전자기기 외의 제품 응답 시 제미나이가 자동 null로 파싱
  - A2338등 애플의 파트넘버가 아닌 모델명으로 검색 시 케이스 등 제품 오검색 문제 보호 로직
- 제미나이 호출 에러 시 최대 2회까지 재호출
  - 제미나이 API 서버 측 에러로 503 응답 시 2회까지는 추가 호출
- API 호출 방식 Vertex AI로 변경
  - 무료 크레딧 정상 차감 (현재 테스트 중)

## ✅ 체크리스트
- [X] 코드 컨벤션을 준수했나요?
- [X] 테스트를 완료했나요?
- [X] 불필요한 주석을 제거했나요?

## 📸 스크린샷 (선택)
<img width="798" height="832" alt="image" src="https://github.com/user-attachments/assets/e08172ec-1062-479e-9dc8-f9d9ed151da7" />
<img width="917" height="765" alt="image" src="https://github.com/user-attachments/assets/ad5e0aba-f2c2-43d6-b59a-2aef3d077705" />
