### PR TITLE
[FEAT] S3 이미지 업로드 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,10 +41,10 @@ dependencies {
 
 
 
-	// AWS 연동 라이브러리 버전 통합 관리 (BOM) - AWS 접속 정보 미비로 인한 에러 방지를 위해 임시 주석 처리
-	// implementation platform('io.awspring.cloud:spring-cloud-aws-dependencies:3.1.1')
+	// AWS 연동 라이브러리 버전 통합 관리 (BOM)
+	implementation platform('io.awspring.cloud:spring-cloud-aws-dependencies:3.1.1')
 	// 기기 이미지 및 영수증 클라우드 업로드 전용 (S3)
-	// implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
+	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
 	// Textract 비동기 OCR 처리 원격 함수 호출 전용 (Lambda)
 	// implementation 'software.amazon.awssdk:lambda'
 

--- a/src/main/java/com/After_Buy/DeviceService/controller/DeviceController.java
+++ b/src/main/java/com/After_Buy/DeviceService/controller/DeviceController.java
@@ -10,9 +10,12 @@ import com.After_Buy.DeviceService.dto.response.HomeSummaryResponse;
 import com.After_Buy.DeviceService.dto.response.DeviceListResponse;
 import com.After_Buy.DeviceService.dto.response.DeviceDetailResponse;
 import com.After_Buy.DeviceService.dto.response.DeviceNameUpdateResponse;
+import com.After_Buy.DeviceService.dto.request.PresignedUrlRequest;
+import com.After_Buy.DeviceService.dto.response.PresignedUrlResponse;
 import com.After_Buy.DeviceService.security.UserPrincipal;
 import com.After_Buy.DeviceService.service.DeviceService;
 import com.After_Buy.DeviceService.service.NaverSearchService;
+import com.After_Buy.DeviceService.service.S3Service;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -43,6 +46,7 @@ public class DeviceController {
 
 	private final DeviceService deviceService;
 	private final NaverSearchService naverSearchService;
+	private final S3Service s3Service;
 
 	/**
 	 * 홈 화면 요약 데이터 조회 API
@@ -211,5 +215,23 @@ public class DeviceController {
 		log.info("기기 삭제 요청: userId={}, deviceId={}", userPrincipal.getUserId(), deviceId);
 		deviceService.deleteDevice(userPrincipal.getUserId(), deviceId);
 		return ResponseEntity.ok(ApiResponse.successMessage("기기가 삭제되었습니다."));
+	}
+
+	/**
+	 * 기기 이미지 S3 직접 업로드용 Presigned URL 발급 API
+	 *
+	 * @param request : 이미지 확장자 정보
+	 * @return : 200 OK + Presigned URL 정보
+	 * @since : 2026.04.12
+	 * @author : 최준혁
+	 */
+	@Tag(name = "Image Upload", description = "이미지 업로드")
+	@Operation(summary = "S3 Pre-signed URL 발급 (기기 이미지 업로드 전용)", description = "S3에 직접 이미지를 업로드하기 위한 Presigned URL을 발급합니다.")
+	@PostMapping("/images/presigned-url")
+	public ResponseEntity<ApiResponse<PresignedUrlResponse>> generatePresignedUrl(
+			@Valid @RequestBody PresignedUrlRequest request) {
+		log.info("S3 Presigned URL 발급 요청: ext={}", request.getFileExtension());
+		PresignedUrlResponse response = s3Service.generatePresignedUrl(request);
+		return ResponseEntity.ok(ApiResponse.success(response));
 	}
 }

--- a/src/main/java/com/After_Buy/DeviceService/dto/request/PresignedUrlRequest.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/request/PresignedUrlRequest.java
@@ -1,0 +1,26 @@
+package com.After_Buy.DeviceService.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 기기 이미지 업로드용 Presigned URL 발급 요청 DTO
+ * 
+ * @since : 2026.04.12
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PresignedUrlRequest {
+
+    // 예: "jpg", "png", "jpeg", "webp"
+    @NotBlank(message = "파일 확장자는 필수 항목입니다.")
+    @JsonProperty("file_extension")
+    private String fileExtension;
+}

--- a/src/main/java/com/After_Buy/DeviceService/dto/response/PresignedUrlResponse.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/response/PresignedUrlResponse.java
@@ -1,0 +1,28 @@
+package com.After_Buy.DeviceService.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 기기 이미지 업로드용 Presigned URL 발급 응답 DTO
+ * 
+ * @since : 2026.04.12
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+public class PresignedUrlResponse {
+
+    @JsonProperty("presigned_url")
+    private String presignedUrl;
+
+    @JsonProperty("image_url")
+    private String imageUrl;
+
+    @JsonProperty("expires_in")
+    private long expiresIn;
+}

--- a/src/main/java/com/After_Buy/DeviceService/exception/ErrorCode.java
+++ b/src/main/java/com/After_Buy/DeviceService/exception/ErrorCode.java
@@ -43,6 +43,9 @@ public enum ErrorCode {
 	/** 타인 소유 물품 권한 없음 (403 Forbidden) */
 	BULK_ACTION_ACCESS_DENIED(HttpStatus.FORBIDDEN, "DEVICE-007", "본인 소유의 항목만 접근할 수 있습니다."),
 
+	/** 지원하지 않는 이미지 확장자 형식 (400 Bad Request) */
+	DEVICE_INVALID_IMAGE_EXTENSION(HttpStatus.BAD_REQUEST, "DEVICE-008", "지원하지 않는 이미지 확장자입니다. (jpg, jpeg, png, webp 가능)"),
+
 	/* ===== 검색 대행 관련 (SEARCH-0XX) ===== */
 
 	/** 네이버 쇼핑 API 검색 결과 없음 */

--- a/src/main/java/com/After_Buy/DeviceService/service/S3Service.java
+++ b/src/main/java/com/After_Buy/DeviceService/service/S3Service.java
@@ -1,0 +1,83 @@
+package com.After_Buy.DeviceService.service;
+
+import com.After_Buy.DeviceService.dto.request.PresignedUrlRequest;
+import com.After_Buy.DeviceService.dto.response.PresignedUrlResponse;
+import com.After_Buy.DeviceService.exception.CustomException;
+import com.After_Buy.DeviceService.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 기기 이미지 S3 전용 서비스
+ * 클라이언트 다이렉트 업로드를 위한 Presigned URL 발급 기능을 수행합니다.
+ * 
+ * @since : 2026.04.12
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Presigner s3Presigner;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucket;
+
+    // 허용하는 이미지 확장자 목록
+    private static final List<String> ALLOWED_EXTENSIONS = List.of("jpg", "jpeg", "png", "webp");
+
+    /**
+     * 클라이언트가 직접 S3 버킷에 이미지를 업로드할 수 있는 Presigned URL을 발급합니다.
+     * 
+     * @param request 사용자 이미지 확장자 (ex. "jpg")
+     * @return PresignedUrlResponse (URL 정보 객체)
+     */
+    public PresignedUrlResponse generatePresignedUrl(PresignedUrlRequest request) {
+        String ext = request.getFileExtension().trim().toLowerCase();
+        
+        if (!ALLOWED_EXTENSIONS.contains(ext)) {
+            log.warn("[S3Service] 지원하지 않는 확장자 요청: {}", ext);
+            throw new CustomException(ErrorCode.DEVICE_INVALID_IMAGE_EXTENSION);
+        }
+
+        // Object Key 생성 규칙: devices/UUID_image.ext
+        String fileName = "devices/" + UUID.randomUUID() + "_image." + ext;
+
+        PutObjectRequest objectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(fileName)
+                .build();
+
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(5)) // 5분 (300초) 설정
+                .putObjectRequest(objectRequest)
+                .build();
+
+        PresignedPutObjectRequest presignedPutObjectRequest = s3Presigner.presignPutObject(presignRequest);
+
+        // 생성된 전체 URL (쿼리 파람 포함)
+        String presignedUrl = presignedPutObjectRequest.url().toString();
+        // 쿼리 파라미터 제외하고 사용할 순수 외부 URL 추출
+        String imageUrl = presignedUrl.split("\\?")[0];
+
+        log.info("[S3Service] Pre-signed URL 생성 완료: {}", imageUrl);
+
+        return PresignedUrlResponse.builder()
+                .presignedUrl(presignedUrl)
+                .imageUrl(imageUrl)
+                .expiresIn(300L) 
+                .build();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,16 +27,16 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
 
-  # AWS 연동 설정 (Spring Cloud AWS) - 임시 설정 파일
-  # cloud:
-  #   aws:
-  #     credentials:
-  #       access-key: ${AWS_ACCESS_KEY}
-  #       secret-key: ${AWS_SECRET_KEY}
-  #     region:
-  #       static: ${AWS_REGION}
-  #     s3:
-  #       bucket: ${AWS_S3_BUCKET}
+  # AWS 연동 설정 (Spring Cloud AWS)
+  cloud:
+    aws:
+      credentials:
+        access-key: ${AWS_ACCESS_KEY}
+        secret-key: ${AWS_SECRET_KEY}
+      region:
+        static: ${AWS_REGION}
+      s3:
+        bucket: ${AWS_S3_BUCKET}
 
 # 내부 서비스 통신용 시크릿 키 (MSA 내부 API 접근 보안)
 internal:

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -29,3 +29,8 @@ naver:
 
 vertex:
   api-key: "test-vertex-api-key"
+
+spring.cloud.aws.credentials.access-key: "mock-access-key"
+spring.cloud.aws.credentials.secret-key: "mock-secret-key"
+spring.cloud.aws.region.static: "ap-northeast-2"
+spring.cloud.aws.s3.bucket: "mock-bucket"


### PR DESCRIPTION
## 📌 개요
#### 제품 이미지 업로드 API S3 presigned-url 연동 구현 완료



## 🛠️ 작업 내용
- S3 presigned-url 방식을 활용한 사용자 개인 제품 이미지 업로드 api 구현



## ✅ 체크리스트
- [X] 코드 컨벤션을 준수했나요?
- [X] 테스트를 완료했나요?
- [X] 불필요한 주석을 제거했나요?

## 📸 스크린샷 (선택)
<img width="726" height="528" alt="image" src="https://github.com/user-attachments/assets/293e19a2-77b6-4273-93b2-22e475fdbd5a" />
<img width="1310" height="964" alt="image" src="https://github.com/user-attachments/assets/458f5716-acab-4c4a-84fc-b9afd3cba396" />
