### PR TITLE
[FEAT] OCR 요청 api 및 로그 기록 api 구현

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -19,6 +19,9 @@ AWS_SECRET_KEY=your_aws_iam_user_secret_key
 AWS_REGION=ap-northeast-2
 AWS_S3_BUCKET=your_s3_bucket_name_for_receipts_and_devices
 
+# AWS Lambda: OCR 처리 (Textract 연동 Lambda 함수명)
+AWS_LAMBDA_FUNCTION_NAME=afterbuy-ocr-textract-lambda
+
 # External API: Naver Shopping (기기 검색용)
 NAVER_CLIENT_ID=your_naver_openapi_client_id
 NAVER_CLIENT_SECRET=your_naver_openapi_client_secret

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 	// 기기 이미지 및 영수증 클라우드 업로드 전용 (S3)
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
 	// Textract 비동기 OCR 처리 원격 함수 호출 전용 (Lambda)
-	// implementation 'software.amazon.awssdk:lambda'
+	implementation 'software.amazon.awssdk:lambda'
 
 	// 앱에서 넘어온 JWT 토큰 페이로드 자체 해석 및 위조 검증용 (JJWT)
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.5'

--- a/src/main/java/com/After_Buy/DeviceService/config/AwsLambdaConfig.java
+++ b/src/main/java/com/After_Buy/DeviceService/config/AwsLambdaConfig.java
@@ -1,0 +1,49 @@
+package com.After_Buy.DeviceService.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.lambda.LambdaClient;
+
+/**
+ * AWS Lambda 클라이언트 설정
+ * OcrService에 주입할 LambdaClient 빈을 등록합니다.
+ * 인증 정보는 application.yaml의 spring.cloud.aws 설정을 공유합니다.
+ *
+ * @since : 2026.04.12
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Configuration
+public class AwsLambdaConfig {
+
+    @Value("${spring.cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${spring.cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    /**
+     * AWS Lambda SDK 클라이언트 빈 등록
+     * IAM 키 기반 정적 인증 방식을 사용합니다.
+     *
+     * @return LambdaClient : Lambda 함수 호출 전용 클라이언트
+     */
+    @Bean
+    public LambdaClient lambdaClient() {
+        return LambdaClient.builder()
+                .region(Region.of(region))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(accessKey, secretKey)
+                        )
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/After_Buy/DeviceService/controller/OcrController.java
+++ b/src/main/java/com/After_Buy/DeviceService/controller/OcrController.java
@@ -1,0 +1,89 @@
+package com.After_Buy.DeviceService.controller;
+
+import com.After_Buy.DeviceService.dto.request.OcrModifiedFieldsRequest;
+import com.After_Buy.DeviceService.dto.request.OcrRequest;
+import com.After_Buy.DeviceService.dto.response.ApiResponse;
+import com.After_Buy.DeviceService.dto.response.OcrResponse;
+import com.After_Buy.DeviceService.security.UserPrincipal;
+import com.After_Buy.DeviceService.service.OcrService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * OCR 처리 컨트롤러
+ * AWS Lambda(Textract)를 통한 OCR 텍스트 추출 및 오인식 필드 기록 API 엔드포인트를 제공합니다.
+ * Base URL: /api/devices/ocr
+ * 포트: 8082
+ * 모든 엔드포인트는 JWT Bearer 토큰 인증 필수입니다.
+ *
+ * @since : 2026.04.12
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/devices/ocr")
+@RequiredArgsConstructor
+@Tag(name = "OCR", description = "OCR 텍스트 추출 및 오인식 기록 API")
+public class OcrController {
+
+    private final OcrService ocrService;
+
+    /**
+     * OCR 텍스트 추출 API
+     * Base64 이미지를 AWS Lambda(Textract)로 전달하여 모델명/시리얼/영수증 정보를 추출합니다.
+     * 처리 이력은 ocr_logs 테이블에 자동 기록됩니다.
+     *
+     * @param userPrincipal : JWT 토큰에서 추출된 인증 사용자 정보
+     * @param request       : OCR 유형과 Base64 인코딩 이미지
+     * @return 200 OK + OCR 인식 결과 (성공/실패 여부 포함)
+     * @since : 2026.04.12
+     * @author : 최준혁
+     */
+    @Operation(
+            summary = "OCR 텍스트 추출",
+            description = "Base64 이미지를 AWS Lambda(Textract)로 전달하여 모델명/시리얼/영수증 정보를 추출합니다."
+    )
+    @PostMapping("")
+    public ResponseEntity<ApiResponse<OcrResponse>> processOcr(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody OcrRequest request) {
+
+        log.info("OCR 처리 요청 - userId={}, ocrType={}", userPrincipal.getUserId(), request.getOcrType());
+        OcrResponse response = ocrService.processOcr(userPrincipal.getUserId(), request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * OCR 오인식 필드 기록 API
+     * OCR 결과를 수정하여 기기를 등록/수정한 후, 어떤 필드를 수정했는지 ocr_logs에 기록합니다.
+     *
+     * @param userPrincipal : JWT 토큰에서 추출된 인증 사용자 정보
+     * @param request       : ocr_log_id, device_id, 수정된 필드 목록
+     * @return 200 OK + 성공 메시지
+     * @since : 2026.04.12
+     * @author : 최준혁
+     */
+    @Operation(
+            summary = "OCR 오인식 필드 기록",
+            description = "OCR 결과를 수정하여 기기를 저장한 후, 수정된 필드 목록을 ocr_logs에 기록합니다."
+    )
+    @PostMapping("/modified-fields")
+    public ResponseEntity<ApiResponse<Void>> recordModifiedFields(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody OcrModifiedFieldsRequest request) {
+
+        log.info("OCR 오인식 필드 기록 요청 - userId={}, ocrLogId={}", userPrincipal.getUserId(), request.getOcrLogId());
+        ocrService.recordModifiedFields(userPrincipal.getUserId(), request);
+        return ResponseEntity.ok(ApiResponse.successMessage("오인식 정보가 기록되었습니다."));
+    }
+}

--- a/src/main/java/com/After_Buy/DeviceService/dto/request/OcrModifiedFieldsRequest.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/request/OcrModifiedFieldsRequest.java
@@ -1,0 +1,41 @@
+package com.After_Buy.DeviceService.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * OCR 오인식 필드 기록 요청 DTO
+ * 사용자가 OCR 결과를 수정하여 기기를 저장한 후,
+ * 어떤 필드를 수정했는지 기록하기 위한 요청입니다.
+ *
+ * @since : 2026.04.12
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class OcrModifiedFieldsRequest {
+
+    // 이전 OCR 호출에서 발급된 로그 ID
+    @NotNull(message = "ocr_log_id는 필수 항목입니다.")
+    @JsonProperty("ocr_log_id")
+    private Long ocrLogId;
+
+    // 결과를 수정하여 등록/수정된 기기 ID
+    @NotNull(message = "device_id는 필수 항목입니다.")
+    @JsonProperty("device_id")
+    private Long deviceId;
+
+    // 사용자가 직접 수정한 필드명 목록 (예: ["purchase_date", "purchase_price"])
+    @NotEmpty(message = "modified_fields는 하나 이상의 항목이 필요합니다.")
+    @JsonProperty("modified_fields")
+    private List<String> modifiedFields;
+}

--- a/src/main/java/com/After_Buy/DeviceService/dto/request/OcrRequest.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/request/OcrRequest.java
@@ -1,0 +1,34 @@
+package com.After_Buy.DeviceService.dto.request;
+
+import com.After_Buy.DeviceService.entity.enums.OcrType;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * OCR 텍스트 추출 요청 DTO
+ * Base64 인코딩된 이미지와 OCR 유형을 전달합니다.
+ *
+ * @since : 2026.04.12
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class OcrRequest {
+
+    // OCR 유형 (MODEL, SERIAL, RECEIPT 중 하나)
+    @NotNull(message = "ocr_type은 필수 항목입니다.")
+    @JsonProperty("ocr_type")
+    private OcrType ocrType;
+
+    // Base64 인코딩된 이미지 데이터
+    @NotBlank(message = "image_base64는 필수 항목입니다.")
+    @JsonProperty("image_base64")
+    private String imageBase64;
+}

--- a/src/main/java/com/After_Buy/DeviceService/dto/response/OcrResponse.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/response/OcrResponse.java
@@ -1,0 +1,42 @@
+package com.After_Buy.DeviceService.dto.response;
+
+import com.After_Buy.DeviceService.entity.enums.OcrType;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * OCR 처리 응답 DTO
+ * OCR 인식 성공/실패 여부와 유형에 따른 결과를 반환합니다.
+ * - is_success: false인 경우 result는 null이고 message 필드 포함.
+ *
+ * @since : 2026.04.12
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class OcrResponse {
+
+    // OCR 처리 유형 (MODEL, SERIAL, RECEIPT)
+    @JsonProperty("ocr_type")
+    private OcrType ocrType;
+
+    // 발급된 OCR 로그 ID (클라이언트가 modified-fields 호출 시 사용)
+    @JsonProperty("ocr_log_id")
+    private Long ocrLogId;
+
+    // OCR 인식 성공 여부
+    @JsonProperty("is_success")
+    private Boolean isSuccess;
+
+    // OCR 인식 결과 (실패 시 null)
+    @JsonProperty("result")
+    private OcrResultDto result;
+
+    // 실패 메시지 (성공 시 null)
+    @JsonProperty("message")
+    private String message;
+}

--- a/src/main/java/com/After_Buy/DeviceService/dto/response/OcrResultDto.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/response/OcrResultDto.java
@@ -1,0 +1,51 @@
+package com.After_Buy.DeviceService.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+/**
+ * OCR 처리 결과 DTO
+ * OCR 유형에 따라 반환되는 필드가 다르며, null 필드는 JSON 직렬화에서 제외됩니다.
+ * - MODEL  : model_name
+ * - SERIAL : serial_number
+ * - RECEIPT: purchase_date, purchase_price, purchase_store
+ *
+ * @since : 2026.04.12
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class OcrResultDto {
+
+    // ===== MODEL 타입 =====
+
+    // 인식된 기기 모델명
+    @JsonProperty("model_name")
+    private String modelName;
+
+    // ===== SERIAL 타입 =====
+
+    // 인식된 시리얼 번호
+    @JsonProperty("serial_number")
+    private String serialNumber;
+
+    // ===== RECEIPT 타입 =====
+
+    // 구매 날짜 (형식: yyyy-MM-dd)
+    @JsonProperty("purchase_date")
+    private String purchaseDate;
+
+    // 구매 가격
+    @JsonProperty("purchase_price")
+    private BigDecimal purchasePrice;
+
+    // 구매처 (판매점 이름)
+    @JsonProperty("purchase_store")
+    private String purchaseStore;
+}

--- a/src/main/java/com/After_Buy/DeviceService/entity/OcrLog.java
+++ b/src/main/java/com/After_Buy/DeviceService/entity/OcrLog.java
@@ -1,0 +1,84 @@
+package com.After_Buy.DeviceService.entity;
+
+import com.After_Buy.DeviceService.entity.enums.OcrType;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * OCR 처리 로그 엔티티
+ * 사용자가 OCR을 호출할 때마다 유형, 성공 여부, 수정 필드를 기록합니다.
+ * DB: device_db.ocr_logs
+ *
+ * @since : 2026.04.12
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "ocr_logs")
+public class OcrLog {
+
+	// OCR 로그 고유 ID (AUTO_INCREMENT)
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "ocr_log_id")
+	private Long ocrLogId;
+
+	// OCR 요청 사용자 ID (auth_db.users 논리 참조)
+	@Column(name = "user_id", nullable = false)
+	private Long userId;
+
+	// 연결된 기기 ID (등록/수정 후 modified-fields 호출 시 업데이트)
+	@Column(name = "device_id")
+	private Long deviceId;
+
+	// OCR 처리 유형 (MODEL, SERIAL, RECEIPT)
+	@Enumerated(EnumType.STRING)
+	@Column(name = "ocr_type", nullable = false, length = 10)
+	private OcrType ocrType;
+
+	// OCR 인식 성공 여부
+	@Column(name = "is_success", nullable = false)
+	private Boolean isSuccess;
+
+	// 사용자가 수정한 필드명 목록 (JSON 배열 형식으로 저장, 예: ["purchase_date", "purchase_price"])
+	@Column(name = "modified_fields", columnDefinition = "JSON")
+	private String modifiedFields;
+
+	// 생성 시각 (자동 설정)
+	@CreationTimestamp
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	/**
+	 * OCR 최초 호출 시 로그 생성용 빌더
+	 *
+	 * @param userId    : 요청 사용자 ID
+	 * @param ocrType   : OCR 유형
+	 * @param isSuccess : 인식 성공 여부
+	 */
+	@Builder
+	public OcrLog(Long userId, OcrType ocrType, Boolean isSuccess) {
+		this.userId = userId;
+		this.ocrType = ocrType;
+		this.isSuccess = isSuccess;
+	}
+
+	/**
+	 * 오인식 필드 기록 업데이트 메서드
+	 * OCR 결과를 수정하여 기기를 저장한 후 호출합니다.
+	 *
+	 * @param deviceId       : 연결된 기기 ID
+	 * @param modifiedFields : 수정된 필드 목록 (JSON 배열 문자열)
+	 */
+	public void updateModifiedFields(Long deviceId, String modifiedFields) {
+		this.deviceId = deviceId;
+		this.modifiedFields = modifiedFields;
+	}
+}

--- a/src/main/java/com/After_Buy/DeviceService/entity/enums/OcrType.java
+++ b/src/main/java/com/After_Buy/DeviceService/entity/enums/OcrType.java
@@ -1,0 +1,21 @@
+package com.After_Buy.DeviceService.entity.enums;
+
+/**
+ * OCR 처리 유형 Enum
+ * 어떤 정보를 추출할 목적으로 OCR을 호출했는지 구분합니다.
+ *
+ * @since : 2026.04.12
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+public enum OcrType {
+
+    /** 기기 모델명 인식 */
+    MODEL,
+
+    /** 기기 시리얼 번호 인식 */
+    SERIAL,
+
+    /** 구매 영수증 정보 인식 */
+    RECEIPT
+}

--- a/src/main/java/com/After_Buy/DeviceService/exception/ErrorCode.java
+++ b/src/main/java/com/After_Buy/DeviceService/exception/ErrorCode.java
@@ -56,6 +56,9 @@ public enum ErrorCode {
 	/** OCR 텍스트 인식 실패 */
 	OCR_RECOGNITION_FAILED(HttpStatus.UNPROCESSABLE_ENTITY, "OCR-001", "이미지에서 텍스트를 인식하지 못했습니다."),
 
+	/** OCR 로그를 찾을 수 없는 경우 (404 Not Found) */
+	OCR_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, "OCR-002", "해당 OCR 로그를 찾을 수 없습니다."),
+
 	/* ===== 공통 (COMMON-0XX) ===== */
 
 	/** @Valid 유효성 검사 실패 */

--- a/src/main/java/com/After_Buy/DeviceService/repository/OcrLogRepository.java
+++ b/src/main/java/com/After_Buy/DeviceService/repository/OcrLogRepository.java
@@ -1,0 +1,15 @@
+package com.After_Buy.DeviceService.repository;
+
+import com.After_Buy.DeviceService.entity.OcrLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * OCR 로그 레포지토리
+ * ocr_logs 테이블에 대한 JPA 쿼리 인터페이스를 제공합니다.
+ *
+ * @since : 2026.04.12
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+public interface OcrLogRepository extends JpaRepository<OcrLog, Long> {
+}

--- a/src/main/java/com/After_Buy/DeviceService/service/OcrService.java
+++ b/src/main/java/com/After_Buy/DeviceService/service/OcrService.java
@@ -1,0 +1,244 @@
+package com.After_Buy.DeviceService.service;
+
+import com.After_Buy.DeviceService.dto.request.OcrModifiedFieldsRequest;
+import com.After_Buy.DeviceService.dto.request.OcrRequest;
+import com.After_Buy.DeviceService.dto.response.OcrResponse;
+import com.After_Buy.DeviceService.dto.response.OcrResultDto;
+import com.After_Buy.DeviceService.entity.OcrLog;
+import com.After_Buy.DeviceService.entity.enums.OcrType;
+import com.After_Buy.DeviceService.exception.CustomException;
+import com.After_Buy.DeviceService.exception.ErrorCode;
+import com.After_Buy.DeviceService.repository.OcrLogRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.lambda.LambdaClient;
+import software.amazon.awssdk.services.lambda.model.InvokeRequest;
+import software.amazon.awssdk.services.lambda.model.InvokeResponse;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * OCR 처리 서비스
+ * AWS Lambda(Textract)를 동기 방식으로 호출하여 OCR 결과를 반환하고
+ * ocr_logs 테이블에 처리 이력을 자동 기록합니다.
+ *
+ * 처리 흐름: 앱 → Device Service → AWS Lambda → Amazon Textract → Lambda 파싱 → Device Service → 앱
+ *
+ * @since : 2026.04.12
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OcrService {
+
+    private final LambdaClient lambdaClient;
+    private final OcrLogRepository ocrLogRepository;
+    private final ObjectMapper objectMapper;
+
+    @Value("${aws.lambda.function-name}")
+    private String lambdaFunctionName;
+
+    /**
+     * OCR 텍스트 추출 메인 메서드
+     * Lambda를 동기 호출하고 결과를 파싱하여 반환하며 ocr_logs에 이력을 기록합니다.
+     *
+     * @param userId  : 요청 사용자 ID (JWT에서 추출)
+     * @param request : OCR 요청 (유형 + Base64 이미지)
+     * @return OcrResponse : OCR 결과 응답
+     */
+    @Transactional
+    public OcrResponse processOcr(Long userId, OcrRequest request) {
+        log.info("[OcrService] OCR 처리 요청 - userId={}, ocrType={}", userId, request.getOcrType());
+
+        // Lambda 요청 페이로드 구성
+        String payload = buildLambdaPayload(request);
+
+        // Lambda 동기 호출
+        InvokeResponse lambdaResponse = invokeLambda(payload);
+
+        // Lambda 응답 파싱
+        String responseJson = lambdaResponse.payload().asUtf8String();
+        log.info("[OcrService] Lambda 응답 수신 - statusCode={}", lambdaResponse.statusCode());
+
+        // 결과 파싱 및 응답 DTO 구성
+        OcrResponse ocrResponse = parseOcrResponse(request.getOcrType(), responseJson);
+
+        // OCR 이력을 DB에 기록 (성공/실패 모두 기록)
+        OcrLog ocrLog = OcrLog.builder()
+                .userId(userId)
+                .ocrType(request.getOcrType())
+                .isSuccess(ocrResponse.getIsSuccess())
+                .build();
+        OcrLog savedLog = ocrLogRepository.save(ocrLog);
+        log.info("[OcrService] OCR 로그 저장 완료 - ocrLogId={}", savedLog.getOcrLogId());
+
+        // 클라이언트가 modified-fields 호출 시 사용할 로그 ID를 응답에 포함
+        return OcrResponse.builder()
+                .ocrType(ocrResponse.getOcrType())
+                .ocrLogId(savedLog.getOcrLogId())
+                .isSuccess(ocrResponse.getIsSuccess())
+                .result(ocrResponse.getResult())
+                .message(ocrResponse.getMessage())
+                .build();
+    }
+
+    /**
+     * OCR 오인식 필드 기록 메서드
+     * 사용자가 OCR 결과를 수정하여 기기를 저장한 후 호출합니다.
+     * 수정된 필드 목록과 연결된 기기 ID를 해당 OCR 로그에 업데이트합니다.
+     *
+     * @param userId  : 요청 사용자 ID (소유권 검증용)
+     * @param request : 오인식 기록 요청 (ocr_log_id, device_id, modified_fields)
+     */
+    @Transactional
+    public void recordModifiedFields(Long userId, OcrModifiedFieldsRequest request) {
+        log.info("[OcrService] OCR 오인식 필드 기록 - userId={}, ocrLogId={}", userId, request.getOcrLogId());
+
+        // OCR 로그 존재 여부 확인
+        OcrLog ocrLog = ocrLogRepository.findById(request.getOcrLogId())
+                .orElseThrow(() -> new CustomException(ErrorCode.OCR_LOG_NOT_FOUND));
+
+        // 수정된 필드 목록을 JSON 배열 문자열로 변환 (예: ["purchase_date","purchase_price"])
+        String modifiedFieldsJson = convertFieldsToJson(request.getModifiedFields());
+
+        // 로그에 기기 ID와 수정 필드 기록
+        ocrLog.updateModifiedFields(request.getDeviceId(), modifiedFieldsJson);
+
+        log.info("[OcrService] OCR 오인식 필드 기록 완료 - ocrLogId={}, modifiedFields={}",
+                request.getOcrLogId(), modifiedFieldsJson);
+    }
+
+    /* ===== Private 내부 메서드 ===== */
+
+    /**
+     * Lambda 호출용 페이로드 JSON 문자열을 생성합니다.
+     *
+     * @param request : OCR 요청 DTO
+     * @return 직렬화된 JSON 페이로드 문자열
+     */
+    private String buildLambdaPayload(OcrRequest request) {
+        try {
+            return objectMapper.writeValueAsString(
+                    new java.util.HashMap<String, String>() {{
+                        put("ocr_type", request.getOcrType().name());
+                        put("image_base64", request.getImageBase64());
+                    }}
+            );
+        } catch (Exception e) {
+            log.error("[OcrService] Lambda 페이로드 생성 실패", e);
+            throw new CustomException(ErrorCode.OCR_RECOGNITION_FAILED);
+        }
+    }
+
+    /**
+     * AWS Lambda를 동기 방식으로 호출합니다.
+     *
+     * @param payload : Lambda에 전달할 JSON 페이로드
+     * @return InvokeResponse : Lambda 응답 객체
+     */
+    private InvokeResponse invokeLambda(String payload) {
+        try {
+            InvokeRequest invokeRequest = InvokeRequest.builder()
+                    .functionName(lambdaFunctionName)
+                    .payload(SdkBytes.fromString(payload, StandardCharsets.UTF_8))
+                    .build();
+            return lambdaClient.invoke(invokeRequest);
+        } catch (Exception e) {
+            log.error("[OcrService] Lambda 호출 실패 - functionName={}", lambdaFunctionName, e);
+            throw new CustomException(ErrorCode.OCR_RECOGNITION_FAILED);
+        }
+    }
+
+    /**
+     * Lambda 응답 JSON을 OCR 유형에 맞게 파싱하여 OcrResponse를 반환합니다.
+     * 인식 실패 시 is_success: false와 안내 메시지를 포함합니다.
+     *
+     * @param ocrType      : OCR 유형
+     * @param responseJson : Lambda가 반환한 JSON 문자열
+     * @return OcrResponse : 파싱된 응답 DTO
+     */
+    private OcrResponse parseOcrResponse(OcrType ocrType, String responseJson) {
+        try {
+            JsonNode root = objectMapper.readTree(responseJson);
+
+            // Lambda에서 is_success 필드로 성공 여부를 내려준다고 가정
+            boolean isSuccess = root.path("is_success").asBoolean(false);
+
+            if (!isSuccess) {
+                // OCR 인식 실패 — 클라이언트에 안내 메시지 반환
+                return OcrResponse.builder()
+                        .ocrType(ocrType)
+                        .isSuccess(false)
+                        .result(null)
+                        .message("텍스트를 인식하지 못했습니다. 다시 시도해주세요.")
+                        .build();
+            }
+
+            // 성공: OCR 유형에 따라 결과 필드를 추출
+            OcrResultDto result = parseResultByType(ocrType, root.path("result"));
+
+            return OcrResponse.builder()
+                    .ocrType(ocrType)
+                    .isSuccess(true)
+                    .result(result)
+                    .build();
+
+        } catch (Exception e) {
+            log.error("[OcrService] Lambda 응답 파싱 실패 - responseJson={}", responseJson, e);
+            throw new CustomException(ErrorCode.OCR_RECOGNITION_FAILED);
+        }
+    }
+
+    /**
+     * OCR 유형별로 result 노드를 파싱하여 OcrResultDto를 반환합니다.
+     *
+     * @param ocrType    : OCR 유형 (MODEL, SERIAL, RECEIPT)
+     * @param resultNode : Lambda 응답 JSON의 result 노드
+     * @return OcrResultDto : 유형별 결과 데이터
+     */
+    private OcrResultDto parseResultByType(OcrType ocrType, JsonNode resultNode) {
+        return switch (ocrType) {
+            case MODEL -> OcrResultDto.builder()
+                    .modelName(resultNode.path("model_name").asText(null))
+                    .build();
+
+            case SERIAL -> OcrResultDto.builder()
+                    .serialNumber(resultNode.path("serial_number").asText(null))
+                    .build();
+
+            case RECEIPT -> OcrResultDto.builder()
+                    .purchaseDate(resultNode.path("purchase_date").asText(null))
+                    .purchasePrice(resultNode.has("purchase_price")
+                            ? new BigDecimal(resultNode.path("purchase_price").asText())
+                            : null)
+                    .purchaseStore(resultNode.path("purchase_store").asText(null))
+                    .build();
+        };
+    }
+
+    /**
+     * 수정된 필드 목록(List)을 JSON 배열 형식의 문자열로 변환합니다.
+     * 예: ["purchase_date", "purchase_price"]
+     *
+     * @param fields : 수정된 필드명 리스트
+     * @return JSON 배열 문자열
+     */
+    private String convertFieldsToJson(List<String> fields) {
+        try {
+            return objectMapper.writeValueAsString(fields);
+        } catch (Exception e) {
+            log.error("[OcrService] modified_fields JSON 변환 실패", e);
+            return "[]";
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -56,3 +56,8 @@ naver:
 # Google Cloud Vertex AI Gemini 연동 설정 (.env 매핑)
 vertex:
   api-key: ${VERTEX_API_KEY}
+
+# AWS Lambda OCR 연동 설정 (.env 매핑)
+aws:
+  lambda:
+    function-name: ${AWS_LAMBDA_FUNCTION_NAME}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -34,3 +34,8 @@ spring.cloud.aws.credentials.access-key: "mock-access-key"
 spring.cloud.aws.credentials.secret-key: "mock-secret-key"
 spring.cloud.aws.region.static: "ap-northeast-2"
 spring.cloud.aws.s3.bucket: "mock-bucket"
+
+aws:
+  lambda:
+    function-name: "mock-lambda-function"
+


### PR DESCRIPTION
## 📌 개요
AWS Lambda 연동을 통한 OCR 텍스트 추출 API와 추후 모델 학습 및 통계를 위한 OCR 오인식 필드 기록 API를 신규 구현했습니다.

## 🛠️ 작업 내용
- **AWS Lambda 연동**: `LambdaClient` 설정 추가 및 동기 호출 서비스(`OcrService`) 구현
- **API 2종 추가**: 
  - `POST /api/devices/ocr`: 이미지 Base64 전달 및 텍스트 추출, `ocr_logs` 1차 기록
  - `POST /api/devices/ocr/modified-fields`: 기기 저장 시 오인식된 필드명 배열 UPDATE
- **DB 및 DTO 최적화**: 
  - `OcrLog` 엔티티 생성, 어드민 통계 쿼리 호환성을 위해 `modified_fields` 컬럼 타입을 `JSON`으로 지정
  - `OcrResultDto`에 `@JsonInclude(NON_NULL)`을 적용하여 OCR 유형(MODEL/SERIAL/RECEIPT)별로 사용하지 않는 빈 필드를 제외하고 응답

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수했나요?
- [x] 테스트를 완료했나요?
- [x] 불필요한 주석을 제거했나요?
