### PR TITLE
feat: notifi -> device 보증 임박 기기 조회 내부 호출 API 구현

### DIFF
--- a/src/main/java/com/After_Buy/DeviceService/controller/InternalDeviceController.java
+++ b/src/main/java/com/After_Buy/DeviceService/controller/InternalDeviceController.java
@@ -1,0 +1,54 @@
+package com.After_Buy.DeviceService.controller;
+
+import com.After_Buy.DeviceService.dto.response.InternalWarrantyExpiringResponse;
+import com.After_Buy.DeviceService.service.InternalDeviceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 인프라 및 서비스 간 내부 통신 제어 컨트롤러
+ * 클라이언트 엔드포인트가 아닌 MSA 아키텍처 상의 타 서비스(Notification, Admin 등)에서 
+ * 자체 통신을 위해 사용합니다. (외부 Nginx 라우팅 미적용)
+ *
+ * @since : 2026.04.12
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Slf4j
+@Tag(name = "Internal Device", description = "MSA 내부 통신 전용 Device API (Notification/Admin/Auth -> Device)")
+@RestController
+@RequestMapping("/internal")
+@RequiredArgsConstructor
+public class InternalDeviceController {
+
+    private final InternalDeviceService internalDeviceService;
+
+    /**
+     * 보증 만료 임박 기기 목록 조회 API
+     * Notification Service의 보증기간 알림 스케줄러가 매일 정해진 시간에 호출합니다.
+     * 결과가 다음 발송 로직의 입력값이므로 동기(Synchronous) 방식으로 처리합니다.
+     *
+     * @param days 남은 일수 지정 (ex: 30, 14, 1, 0)
+     * @return 일자 조건에 해당하는 기기 목록
+     */
+    @Operation(summary = "[Internal] 보증 만료 목록 조회",
+               description = "보증 만료일이 정확히 N일 남은(D-N) 기기 목록을 반환합니다. (Notification 스케줄러 호출용)")
+    @Parameter(name = "X-Internal-Secret", description = "내부 보안 키", required = true, in = ParameterIn.HEADER, schema = @Schema(type = "string"))
+    @GetMapping("/devices/warranty-expiring")
+    public ResponseEntity<InternalWarrantyExpiringResponse> getWarrantyExpiringDevices(
+            @RequestParam("days") int days) {
+        
+        log.info("Internal API 호출 - 보증 만료 {}일 남은 기기 조회", days);
+        return ResponseEntity.ok(internalDeviceService.getWarrantyExpiringDevices(days));
+    }
+}

--- a/src/main/java/com/After_Buy/DeviceService/dto/response/ExpiringDeviceDto.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/response/ExpiringDeviceDto.java
@@ -1,0 +1,33 @@
+package com.After_Buy.DeviceService.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 보증 만료 임박 기기 DTO
+ * 내부 통신 시 전달되는 기기 정보 항목
+ *
+ * @since : 2026.04.12
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@Builder
+public class ExpiringDeviceDto {
+
+    @JsonProperty("device_id")
+    private Long deviceId;
+
+    @JsonProperty("user_id")
+    private Long userId;
+
+    @JsonProperty("product_name")
+    private String productName;
+
+    @JsonProperty("image_url")
+    private String imageUrl;
+
+    @JsonProperty("warranty_expiry_date")
+    private String warrantyExpiryDate;
+}

--- a/src/main/java/com/After_Buy/DeviceService/dto/response/InternalWarrantyExpiringResponse.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/response/InternalWarrantyExpiringResponse.java
@@ -1,0 +1,21 @@
+package com.After_Buy.DeviceService.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 보증 만료 임박 목록 응답 DTO
+ * 내부 통신을 통해 반환되는 루트 객체
+ *
+ * @since : 2026.04.12
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@Builder
+public class InternalWarrantyExpiringResponse {
+
+    private List<ExpiringDeviceDto> devices;
+}

--- a/src/main/java/com/After_Buy/DeviceService/repository/DeviceRepository.java
+++ b/src/main/java/com/After_Buy/DeviceService/repository/DeviceRepository.java
@@ -69,4 +69,14 @@ public interface DeviceRepository extends JpaRepository<Device, Long> {
            "AND (LOWER(d.productName) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
            "OR LOWER(d.brand) LIKE LOWER(CONCAT('%', :keyword, '%')))")
     List<Device> searchByUserIdAndKeyword(@Param("userId") Long userId, @Param("keyword") String keyword);
+
+    /**
+     * D-Day 알림을 위한 보증 만료 일자 일치 기기 목록 조회 (Internal API용)
+     * Spring Boot 애플리케이션에서 계산된 정확한 타겟 날짜로 조회합니다. (DB Timezone 이슈 방지)
+     *
+     * @param targetDate : 조회할 기준 만료일 (오늘 날짜 + days)
+     * @return : 해당 일자에 보증이 만료되는 기기 목록
+     */
+    @Query(value = "SELECT * FROM devices WHERE warranty_expiry_date = :targetDate", nativeQuery = true)
+    List<Device> findByWarrantyExpiryDateDday(@Param("targetDate") LocalDate targetDate);
 }

--- a/src/main/java/com/After_Buy/DeviceService/service/InternalDeviceService.java
+++ b/src/main/java/com/After_Buy/DeviceService/service/InternalDeviceService.java
@@ -1,0 +1,62 @@
+package com.After_Buy.DeviceService.service;
+
+import com.After_Buy.DeviceService.dto.response.ExpiringDeviceDto;
+import com.After_Buy.DeviceService.dto.response.InternalWarrantyExpiringResponse;
+import com.After_Buy.DeviceService.entity.Device;
+import com.After_Buy.DeviceService.repository.DeviceRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 인프라 및 서비스 간 내부 통신용 서비스
+ * 
+ * @since : 2026.04.12
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InternalDeviceService {
+
+        private final DeviceRepository deviceRepository;
+
+        /**
+         * 보증 만료 D-day 기기 목록 조회
+         * 
+         * @param days : 남은 보증 기간 일수 (ex: 30, 14, 1, 0)
+         * @return InternalWarrantyExpiringResponse
+         */
+        @Transactional(readOnly = true)
+        public InternalWarrantyExpiringResponse getWarrantyExpiringDevices(int days) {
+                log.info("[InternalDeviceService] 보증 만료 임박(D-{}) 기기 조회", days);
+
+                // DB 서버의 타임존(UTC)과 애플리케이션 서버(KST)의 시차가 발생할 수 있으므로,
+                // 확실히 KST 기준의 Spring Boot 시간으로 타겟 날짜를 계산해서 쿼리에 넣습니다.
+                LocalDate targetDate = LocalDate.now().plusDays(days);
+
+                List<Device> devices = deviceRepository.findByWarrantyExpiryDateDday(targetDate);
+
+                List<ExpiringDeviceDto> dtos = devices.stream()
+                                .map(device -> ExpiringDeviceDto.builder()
+                                                .deviceId(device.getDeviceId())
+                                                .userId(device.getUserId())
+                                                .productName(device.getProductName())
+                                                .imageUrl(device.getImageUrl())
+                                                .warrantyExpiryDate(device.getWarrantyExpiryDate() != null
+                                                                ? device.getWarrantyExpiryDate().toString()
+                                                                : null)
+                                                .build())
+                                .collect(Collectors.toList());
+
+                return InternalWarrantyExpiringResponse.builder()
+                                .devices(dtos)
+                                .build();
+        }
+}


### PR DESCRIPTION
## 📌 개요
#### Notification -> Device의 보증 기간 만료 임박 기기(30,14,1,0)를 스케줄러가 호출함에 따라 응답하는 API



## 🛠️ 작업 내용
- API 구현
- 테스트 (Device Service에서 자체 API 테스트는 성공)
 - Notification에서 정상적으로 호출되는지 테스트 필요 



## ✅ 체크리스트
- [X] 코드 컨벤션을 준수했나요?
- [X] 테스트를 완료했나요?
- [X] 불필요한 주석을 제거했나요?

## 📸 스크린샷 (선택)
<img width="618" height="882" alt="image" src="https://github.com/user-attachments/assets/e2efb7a5-48fa-4c21-adb5-488d67b2c2cf" />
