### PR TITLE
[FEAT] auth->device 회원 탈퇴 시 기기 내역 Cascade 삭제 api 구현

### DIFF
--- a/src/main/java/com/After_Buy/DeviceService/controller/InternalDeviceController.java
+++ b/src/main/java/com/After_Buy/DeviceService/controller/InternalDeviceController.java
@@ -1,6 +1,7 @@
 package com.After_Buy.DeviceService.controller;
 
 import com.After_Buy.DeviceService.dto.response.InternalWarrantyExpiringResponse;
+import com.After_Buy.DeviceService.dto.response.InternalDeleteUserDataResponse;
 import com.After_Buy.DeviceService.service.InternalDeviceService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -11,9 +12,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.concurrent.CompletableFuture;
 
 /**
  * 인프라 및 서비스 간 내부 통신 제어 컨트롤러
@@ -50,5 +55,33 @@ public class InternalDeviceController {
         
         log.info("Internal API 호출 - 보증 만료 {}일 남은 기기 조회", days);
         return ResponseEntity.ok(internalDeviceService.getWarrantyExpiringDevices(days));
+    }
+
+    /**
+     * 회원 탈퇴 시 사용자 연관 데이터 전체 삭제 API
+     * Auth Service가 회원 탈퇴 처리 시 호출합니다.
+     * 
+     * @param userId 탈퇴하려는 사용자 ID
+     * @return 즉시 200 OK와 삭제 접수 상태를 반환
+     */
+    @Operation(summary = "[Internal] 회원 전체 데이터 삭제 (비동기)",
+               description = "회원 탈퇴 시 호출되어 해당 사용자의 OCR, 기기, 폴더 데이터를 연쇄 삭제합니다. (Auth 호출용)")
+    @Parameter(name = "X-Internal-Secret", description = "내부 보안 키", required = true, in = ParameterIn.HEADER, schema = @Schema(type = "string"))
+    @DeleteMapping("/devices/users/{userId}")
+    public ResponseEntity<InternalDeleteUserDataResponse> deleteUserData(
+            @PathVariable("userId") Long userId) {
+        
+        log.info("Internal API 호출 - 회원(userId={}) 탈퇴 데이터 삭제 요청 접수 (비동기 처리 진행)", userId);
+        
+        // Fire & Forget 적용: 응답에 지장을 주지 않도록 백그라운드 스레드에서 삭제 수행
+        CompletableFuture.runAsync(() -> internalDeviceService.deleteAllUserData(userId));
+
+        // 삭제 작업 완료를 기다리지 않고 명세서 기준 즉시 200 OK를 반환합니다.
+        return ResponseEntity.ok(
+                InternalDeleteUserDataResponse.builder()
+                        .deleted(true)
+                        .user_id(userId)
+                        .build()
+        );
     }
 }

--- a/src/main/java/com/After_Buy/DeviceService/dto/response/InternalDeleteUserDataResponse.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/response/InternalDeleteUserDataResponse.java
@@ -1,0 +1,20 @@
+package com.After_Buy.DeviceService.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 탈퇴로 인한 기기 관련 데이터 전체 삭제 응답 DTO
+ *
+ * @since : 2026.04.12
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@Builder
+public class InternalDeleteUserDataResponse {
+
+    private boolean deleted;
+    
+    private Long user_id;
+}

--- a/src/main/java/com/After_Buy/DeviceService/repository/DeviceRepository.java
+++ b/src/main/java/com/After_Buy/DeviceService/repository/DeviceRepository.java
@@ -4,6 +4,7 @@ import com.After_Buy.DeviceService.entity.Device;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.repository.Modifying;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -52,9 +53,9 @@ public interface DeviceRepository extends JpaRepository<Device, Long> {
     Long countByFolderId(Long folderId);
 
     // 특정 폴더 내부에 포함된 모든 기기를 일괄 삭제 (애플리케이션 레벨 CASCADE 용)
-    @org.springframework.data.jpa.repository.Modifying
-    @org.springframework.data.jpa.repository.Query("DELETE FROM Device d WHERE d.folderId = :folderId")
-    void deleteByFolderId(@org.springframework.data.repository.query.Param("folderId") Long folderId);
+    @Modifying
+    @Query("DELETE FROM Device d WHERE d.folderId = :folderId")
+    void deleteByFolderId(@Param("folderId") Long folderId);
 
     /**
      * 상품명 또는 브랜드 키워드 부분 검색 (통합 검색용)
@@ -79,4 +80,11 @@ public interface DeviceRepository extends JpaRepository<Device, Long> {
      */
     @Query(value = "SELECT * FROM devices WHERE warranty_expiry_date = :targetDate", nativeQuery = true)
     List<Device> findByWarrantyExpiryDateDday(@Param("targetDate") LocalDate targetDate);
+
+    /**
+     * 특정 사용자 기기 전부 일괄 삭제 (벌크 연산)
+     */
+    @Modifying
+    @Query("DELETE FROM Device d WHERE d.userId = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/After_Buy/DeviceService/repository/FolderRepository.java
+++ b/src/main/java/com/After_Buy/DeviceService/repository/FolderRepository.java
@@ -5,6 +5,7 @@ import com.After_Buy.DeviceService.entity.Folder;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.repository.Modifying;
 
 import java.util.Optional;
 import java.util.List;
@@ -86,5 +87,11 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 	 * @return : 매칭된 폴더 목록
 	 */
 	List<Folder> findByUserIdAndFolderNameContainingIgnoreCase(Long userId, String keyword);
-}
 
+	/**
+	 * 특정 사용자 폴더 전부 일괄 삭제 (벌크 연산)
+	 */
+	@Modifying
+	@Query("DELETE FROM Folder f WHERE f.userId = :userId")
+	void deleteAllByUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/com/After_Buy/DeviceService/repository/OcrLogRepository.java
+++ b/src/main/java/com/After_Buy/DeviceService/repository/OcrLogRepository.java
@@ -2,6 +2,9 @@ package com.After_Buy.DeviceService.repository;
 
 import com.After_Buy.DeviceService.entity.OcrLog;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /**
  * OCR 로그 레포지토리
@@ -12,4 +15,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * @author : 최준혁
  */
 public interface OcrLogRepository extends JpaRepository<OcrLog, Long> {
+
+    /**
+     * 특정 사용자 OCR 로그 일괄 삭제 (벌크 연산)
+     */
+    @Modifying
+    @Query("DELETE FROM OcrLog o WHERE o.userId = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/After_Buy/DeviceService/service/InternalDeviceService.java
+++ b/src/main/java/com/After_Buy/DeviceService/service/InternalDeviceService.java
@@ -4,6 +4,8 @@ import com.After_Buy.DeviceService.dto.response.ExpiringDeviceDto;
 import com.After_Buy.DeviceService.dto.response.InternalWarrantyExpiringResponse;
 import com.After_Buy.DeviceService.entity.Device;
 import com.After_Buy.DeviceService.repository.DeviceRepository;
+import com.After_Buy.DeviceService.repository.FolderRepository;
+import com.After_Buy.DeviceService.repository.OcrLogRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -26,6 +28,8 @@ import java.util.stream.Collectors;
 public class InternalDeviceService {
 
         private final DeviceRepository deviceRepository;
+        private final FolderRepository folderRepository;
+        private final OcrLogRepository ocrLogRepository;
 
         /**
          * 보증 만료 D-day 기기 목록 조회
@@ -58,5 +62,27 @@ public class InternalDeviceService {
                 return InternalWarrantyExpiringResponse.builder()
                                 .devices(dtos)
                                 .build();
+        }
+
+        /**
+         * 회원 탈퇴 시 해당 사용자의 모든 기기 정보(OCR, 기기, 폴더)를 연쇄 삭제
+         * 
+         * @param userId 회원 탈퇴를 요청한 사용자 ID
+         */
+        @Transactional
+        public void deleteAllUserData(Long userId) {
+                log.info("[InternalDeviceService] 회원 탈퇴에 따른 사용자(userId={}) 데이터 전체 삭제 시작", userId);
+                try {
+                        // 1. 외래키를 갖고 있는 참조 데이터를 가장 안쪽부터 삭제(ocr_logs)
+                        ocrLogRepository.deleteAllByUserId(userId);
+                        // 2. 부모 객체를 가진 devices 삭제
+                        deviceRepository.deleteAllByUserId(userId);
+                        // 3. 최상위(단, 재귀 부모를 가질 수 있는) folders 삭제
+                        folderRepository.deleteAllByUserId(userId);
+
+                        log.info("[InternalDeviceService] 삭제 성공 - 사용자(userId={})의 모든 데이터 영구 정리 완료", userId);
+                } catch (Exception e) {
+                        log.error("[InternalDeviceService] 삭제 중 심각한 오류 발생 - 사용자(userId={})의 기기 데이터 제거 실패", userId, e);
+                }
         }
 }

--- a/src/main/java/com/After_Buy/DeviceService/service/InternalDeviceService.java
+++ b/src/main/java/com/After_Buy/DeviceService/service/InternalDeviceService.java
@@ -73,14 +73,12 @@ public class InternalDeviceService {
         public void deleteAllUserData(Long userId) {
                 log.info("[InternalDeviceService] 회원 탈퇴에 따른 사용자(userId={}) 데이터 전체 삭제 시작", userId);
                 try {
-                        // 1. 외래키를 갖고 있는 참조 데이터를 가장 안쪽부터 삭제(ocr_logs)
-                        ocrLogRepository.deleteAllByUserId(userId);
-                        // 2. 부모 객체를 가진 devices 삭제
+                        // 1. 부모 객체를 가진 devices 삭제 (OCR 로그는 통계 집계용으로 삭제하지 않고 보존)
                         deviceRepository.deleteAllByUserId(userId);
-                        // 3. 최상위(단, 재귀 부모를 가질 수 있는) folders 삭제
+                        // 2. 최상위(단, 재귀 부모를 가질 수 있는) folders 삭제
                         folderRepository.deleteAllByUserId(userId);
 
-                        log.info("[InternalDeviceService] 삭제 성공 - 사용자(userId={})의 모든 데이터 영구 정리 완료", userId);
+                        log.info("[InternalDeviceService] 삭제 성공 - 사용자(userId={})의 모든 데이터 영구 정리 완료 (OCR 로그 제외)", userId);
                 } catch (Exception e) {
                         log.error("[InternalDeviceService] 삭제 중 심각한 오류 발생 - 사용자(userId={})의 기기 데이터 제거 실패", userId, e);
                 }


### PR DESCRIPTION
## 📌 개요
#### 회원 탈퇴 시 해당 회원과 관련된 폴더, 기기 데이터 삭제



## 🛠️ 작업 내용
- cascade Delete API 구현
  - 폴더 구조에 따라 device 먼저 삭제 후 폴더 삭제 하도록 구현
- OCR 로그 데이터는 미삭제로 변경
 - 전체 통계에 영향 없도록 데이터 유지



## ✅ 체크리스트
- [X] 코드 컨벤션을 준수했나요?
- [X] 테스트를 완료했나요?
- [X] 불필요한 주석을 제거했나요?

## 📸 스크린샷 (선택)
<img width="699" height="484" alt="image" src="https://github.com/user-attachments/assets/db539679-9dfb-4182-aebb-b79dd4f48dd5" />
