### PR TITLE
feat: admin->device OCR 로그 전체 조회 api 구현

### DIFF
--- a/src/main/java/com/After_Buy/DeviceService/controller/InternalDeviceController.java
+++ b/src/main/java/com/After_Buy/DeviceService/controller/InternalDeviceController.java
@@ -1,5 +1,8 @@
 package com.After_Buy.DeviceService.controller;
 
+import java.time.LocalDate;
+
+import com.After_Buy.DeviceService.dto.response.OcrStatsResponse;
 import com.After_Buy.DeviceService.dto.response.InternalWarrantyExpiringResponse;
 import com.After_Buy.DeviceService.dto.response.InternalDeleteUserDataResponse;
 import com.After_Buy.DeviceService.service.InternalDeviceService;
@@ -83,5 +86,26 @@ public class InternalDeviceController {
                         .user_id(userId)
                         .build()
         );
+    }
+
+    /**
+     * 기간별 OCR 통계 정보 조회 API
+     * Admin Service의 대시보드 표시에 필요한 통계 집계를 위함.
+     * 결과가 즉시 필요한 화면용 데이터이므로 동기(Synchronous) 처리합니다.
+     *
+     * @param startDate 집계 시작일
+     * @param endDate 집계 종료일
+     * @return 집계된 통계 객체 (OcrStatsResponse)
+     */
+    @Operation(summary = "[Internal] OCR 통계 조회",
+               description = "Admin Service 대시보드용으로 기간별 OCR 시도, 실패, 수정 및 실패 트렌드 통계를 반환합니다.")
+    @Parameter(name = "X-Internal-Secret", description = "내부 보안 키", required = true, in = ParameterIn.HEADER, schema = @Schema(type = "string"))
+    @GetMapping("/ocr-stats")
+    public ResponseEntity<OcrStatsResponse> getOcrStats(
+            @RequestParam("start_date") LocalDate startDate,
+            @RequestParam("end_date") LocalDate endDate) {
+
+        log.info("Internal API 호출 - OCR 통계 조회 ({} ~ {})", startDate, endDate);
+        return ResponseEntity.ok(internalDeviceService.getOcrStats(startDate, endDate));
     }
 }

--- a/src/main/java/com/After_Buy/DeviceService/dto/response/DailyFailureTrendDto.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/response/DailyFailureTrendDto.java
@@ -1,0 +1,23 @@
+package com.After_Buy.DeviceService.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 통계용 일간 실패 트렌드 DTO
+ *
+ * @since : 2026.04.12
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@Builder
+public class DailyFailureTrendDto {
+
+    @JsonProperty("date")
+    private String date;
+
+    @JsonProperty("failure_count")
+    private Long failureCount;
+}

--- a/src/main/java/com/After_Buy/DeviceService/dto/response/FieldModifiedStatDto.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/response/FieldModifiedStatDto.java
@@ -1,0 +1,23 @@
+package com.After_Buy.DeviceService.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 통계용 필드 수정 현황 DTO
+ *
+ * @since : 2026.04.12
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@Builder
+public class FieldModifiedStatDto {
+
+    @JsonProperty("field_name")
+    private String fieldName;
+
+    @JsonProperty("modified_count")
+    private Long modifiedCount;
+}

--- a/src/main/java/com/After_Buy/DeviceService/dto/response/OcrStatsResponse.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/response/OcrStatsResponse.java
@@ -1,0 +1,34 @@
+package com.After_Buy.DeviceService.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+import java.util.List;
+
+/**
+ * OCR 통계 응답 DTO
+ * Admin Service 통계 화면 표출용
+ *
+ * @since : 2026.04.12
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@Builder
+public class OcrStatsResponse {
+
+    @JsonProperty("total_attempts")
+    private Long totalAttempts;
+
+    @JsonProperty("failure_count")
+    private Long failureCount;
+
+    @JsonProperty("modified_count")
+    private Long modifiedCount;
+
+    @JsonProperty("field_modified_stats")
+    private List<FieldModifiedStatDto> fieldModifiedStats;
+
+    @JsonProperty("daily_failure_trend")
+    private List<DailyFailureTrendDto> dailyFailureTrend;
+}

--- a/src/main/java/com/After_Buy/DeviceService/repository/OcrLogRepository.java
+++ b/src/main/java/com/After_Buy/DeviceService/repository/OcrLogRepository.java
@@ -22,4 +22,30 @@ public interface OcrLogRepository extends JpaRepository<OcrLog, Long> {
     @Modifying
     @Query("DELETE FROM OcrLog o WHERE o.userId = :userId")
     void deleteAllByUserId(@Param("userId") Long userId);
+
+    /**
+     * 특정 기간 동안의 전체 OCR 시도 횟수
+     */
+    long countByCreatedAtBetween(java.time.LocalDateTime start, java.time.LocalDateTime end);
+
+    /**
+     * 특정 기간 동안의 OCR 실패 횟수
+     */
+    long countByIsSuccessFalseAndCreatedAtBetween(java.time.LocalDateTime start, java.time.LocalDateTime end);
+
+    /**
+     * 특정 기간 내 지정된 필드가 배열로 저장되어 있는(유저가 수정한) 레코드들의 modifiedFields 문자열 리스트 반환
+     */
+    @Query("SELECT o.modifiedFields FROM OcrLog o WHERE o.modifiedFields IS NOT NULL AND o.createdAt >= :start AND o.createdAt <= :end")
+    java.util.List<String> findModifiedFieldsByCreatedAtBetween(@Param("start") java.time.LocalDateTime start, @Param("end") java.time.LocalDateTime end);
+
+    /**
+     * 특정 기간 내의 일별 실패 트렌드 집계
+     */
+    @Query(value = "SELECT DATE(o.created_at) as date, COUNT(*) as failureCount " +
+                   "FROM ocr_logs o " +
+                   "WHERE o.is_success = false AND o.created_at >= :start AND o.created_at <= :end " +
+                   "GROUP BY DATE(o.created_at) " +
+                   "ORDER BY date", nativeQuery = true)
+    java.util.List<Object[]> findDailyFailureTrendRaw(@Param("start") java.time.LocalDateTime start, @Param("end") java.time.LocalDateTime end);
 }

--- a/src/main/java/com/After_Buy/DeviceService/service/InternalDeviceService.java
+++ b/src/main/java/com/After_Buy/DeviceService/service/InternalDeviceService.java
@@ -12,8 +12,20 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.After_Buy.DeviceService.dto.response.OcrStatsResponse;
+import com.After_Buy.DeviceService.dto.response.FieldModifiedStatDto;
+import com.After_Buy.DeviceService.dto.response.DailyFailureTrendDto;
 
 /**
  * 인프라 및 서비스 간 내부 통신용 서비스
@@ -30,6 +42,7 @@ public class InternalDeviceService {
         private final DeviceRepository deviceRepository;
         private final FolderRepository folderRepository;
         private final OcrLogRepository ocrLogRepository;
+        private final ObjectMapper objectMapper;
 
         /**
          * 보증 만료 D-day 기기 목록 조회
@@ -82,5 +95,75 @@ public class InternalDeviceService {
                 } catch (Exception e) {
                         log.error("[InternalDeviceService] 삭제 중 심각한 오류 발생 - 사용자(userId={})의 기기 데이터 제거 실패", userId, e);
                 }
+        }
+
+        /**
+         * 지정된 기간 동안의 OCR 통계(시도/실패/수정) 정보 조회
+         * @param startDate 시작일
+         * @param endDate 종료일
+         * @return OCR 통계 데이터가 담긴 OcrStatsResponse
+         */
+        @Transactional(readOnly = true)
+        public OcrStatsResponse getOcrStats(LocalDate startDate, LocalDate endDate) {
+                log.info("[InternalDeviceService] OCR 통계 집계 요청: {} ~ {}", startDate, endDate);
+
+                // 파라미터로 넘어온 LocalDate를 00:00:00 ~ 23:59:59 형태의 LocalDateTime으로 변환
+                LocalDateTime startDateTime = startDate.atStartOfDay();
+                LocalDateTime endDateTime = endDate.atTime(LocalTime.MAX);
+
+                // 1. 단순 aggregate count 도출
+                long totalAttempts = ocrLogRepository.countByCreatedAtBetween(startDateTime, endDateTime);
+                long failureCount = ocrLogRepository.countByIsSuccessFalseAndCreatedAtBetween(startDateTime, endDateTime);
+
+                // 2. field_modified_stats 및 modified_count 도출
+                List<String> modifiedFieldsJsonList = ocrLogRepository.findModifiedFieldsByCreatedAtBetween(startDateTime, endDateTime);
+
+                // modified_count는 빈 JSON 배열이나 유효하지 않은 기록 등을 제외하고, 실제로 필드를 하나라도 수정한 '로그의 건수'라고 정의함
+                long modifiedCount = 0;
+                Map<String, Long> fieldFrequencyMap = new HashMap<>();
+
+                for (String jsonText : modifiedFieldsJsonList) {
+                        try {
+                                List<String> fields = objectMapper.readValue(jsonText, new TypeReference<List<String>>() {});
+                                if (fields != null && !fields.isEmpty()) {
+                                        modifiedCount++;
+                                        for (String field : fields) {
+                                                fieldFrequencyMap.put(field, fieldFrequencyMap.getOrDefault(field, 0L) + 1L);
+                                        }
+                                }
+                        } catch (JsonProcessingException e) {
+                                log.warn("[InternalDeviceService] OCR 수정 빈도 JSON 파싱 오류: {}", jsonText, e);
+                        }
+                }
+
+                // Map 형태의 빈도를 FieldModifiedStatDto 목록으로 치환 후, 내림차순 정렬
+                List<FieldModifiedStatDto> fieldStats = fieldFrequencyMap.entrySet().stream()
+                                .map(entry -> FieldModifiedStatDto.builder()
+                                                .fieldName(entry.getKey())
+                                                .modifiedCount(entry.getValue())
+                                                .build())
+                                .sorted((a, b) -> Long.compare(b.getModifiedCount(), a.getModifiedCount()))
+                                .collect(Collectors.toList());
+
+                // 3. daily_failure_trend 도출 (Native Query의 List<Object[]> 매핑)
+                List<Object[]> rawTrend = ocrLogRepository.findDailyFailureTrendRaw(startDateTime, endDateTime);
+                List<DailyFailureTrendDto> dailyTrend = rawTrend.stream().map(row -> {
+                        // row[0]은 DATE 형태(java.sql.Date 또는 String), row[1]은 카운트 수(Number)
+                        String dateStr = row[0].toString();
+                        Long failCnt = ((Number) row[1]).longValue();
+
+                        return DailyFailureTrendDto.builder()
+                                        .date(dateStr)
+                                        .failureCount(failCnt)
+                                        .build();
+                }).collect(Collectors.toList());
+
+                return OcrStatsResponse.builder()
+                                .totalAttempts(totalAttempts)
+                                .failureCount(failureCount)
+                                .modifiedCount(modifiedCount)
+                                .fieldModifiedStats(fieldStats)
+                                .dailyFailureTrend(dailyTrend)
+                                .build();
         }
 }


### PR DESCRIPTION
## 📌 개요
Admin Service의 대시보드 화면 렌더링에 필요한 기간별 OCR 처리 통계 정보를 제공하기 위해, Device Service 측에 내부 통신 전용 `GET /internal/ocr-stats` API를 구현하였습니다.

## 🛠️ 작업 내용
- **DTO 객체 모델링**: API 명세서에 맞춘 snake_case 기반의 응답용 객체(`OcrStatsResponse`, `FieldModifiedStatDto`, `DailyFailureTrendDto`) 신규 생성
- **Repository 쿼리 구성**:
  - `total_attempts`, `failure_count`를 산출하기 위한 `createdAt` 기간 기반 쿼리 작성
  - 일간 실패 트렌드 도출을 위해 `Native Query`와 `DATE()` 함수를 사용하여 DB 딴에서 그룹핑 로직 추가
- **Service 통계 로직 구현 (`InternalDeviceService`)**:
  - 사용자별로 오인식되어 수정된(modified_fields) 필드 데이터(JSON 문자열 배열)를 `Jackson ObjectMapper`로 메모리에 안전하게 로드 후 빈도수 집계
  - 많이 수정된 주요 필드 기준 내림차순 정렬 로직 적용
- **Controller 매핑 (`InternalDeviceController`)**:
  - 관리자 화면의 즉각적인 렌더링이 필수이므로 동기(Synchronous) 방식으로 엔드포인트 세팅 완료

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수했나요?
- [x] 테스트를 완료했나요?
- [x] 불필요한 주석을 제거했나요?


## 📸 스크린샷 (선택)
<img width="670" height="589" alt="image" src="https://github.com/user-attachments/assets/39767b2a-7060-4155-931e-f75daa7ecf42" />
