### PR TITLE
feat: 기기 서비스 에러 파이프라인 클라이언트 통합

### DIFF
--- a/src/main/java/com/After_Buy/DeviceService/client/AdminInternalClient.java
+++ b/src/main/java/com/After_Buy/DeviceService/client/AdminInternalClient.java
@@ -1,0 +1,71 @@
+package com.After_Buy.DeviceService.client;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+/**
+ * Admin Service 내부 API 호출 클라이언트
+ * 500급 서버 예외 발생 시 Admin Service의 에러 로그 수집 API로 비동기 전송합니다.
+ *
+ * 설계 원칙:
+ * - Fire & Forget: 에러 전송 지연이 원래 API 처리를 지연시켜서는 안 됩니다.
+ * - .onErrorResume: Admin Service 다운 시에도 타 서비스 가용성에 영향 없도록 에러 무시.
+ * - 오직 Exception.class 핸들러에서만 호출됩니다. (4xx 에러는 호출 제외)
+ *
+ * @since : 2026.04.26
+ * @version : 1.0.0
+ * @author : 신태훈
+ */
+@Slf4j
+@Component
+public class AdminInternalClient {
+
+    private final WebClient webClient;
+
+    public AdminInternalClient(
+            WebClient.Builder webClientBuilder,
+            @Value("${services.admin-url}") String adminUrl,
+            @Value("${internal.secret-key}") String internalSecretKey) {
+        this.webClient = webClientBuilder
+                .baseUrl(adminUrl)
+                .defaultHeader("X-Internal-Secret", internalSecretKey)
+                .build();
+    }
+
+    /**
+     * Admin Service로 500급 서버 크래시 에러 로그를 비동기 전송합니다. (Fire & Forget)
+     * Admin Service 다운 시에도 .onErrorResume으로 에러를 무시하여 Device Service 가용성을 보호합니다.
+     *
+     * @param endpointPath : 에러 발생 엔드포인트 경로
+     * @param e            : 발생한 예외
+     */
+    public void sendErrorLogAsync(String endpointPath, Exception e) {
+        String errorMessage = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+
+        Map<String, Object> body = Map.of(
+                "service_name", "DEVICE",
+                "endpoint_path", endpointPath,
+                "error_type", e.getClass().getSimpleName(),
+                "error_message", errorMessage.length() > 500 ? errorMessage.substring(0, 497) + "..." : errorMessage,
+                "occurred_at", LocalDateTime.now().toString()
+        );
+
+        webClient.post()
+                .uri("/internal/error-logs")
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(Void.class)
+                .onErrorResume(error -> {
+                    /* Admin Service 연결 실패 시 경고 로그만 출력하고 무시 (2차 장애 방지) */
+                    log.warn("[AdminInternalClient] 에러 로그 전송 실패 (무시): {}", error.getMessage());
+                    return Mono.empty();
+                })
+                .subscribe(); // 비동기 실행 (Fire & Forget)
+    }
+}

--- a/src/main/java/com/After_Buy/DeviceService/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/After_Buy/DeviceService/exception/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.After_Buy.DeviceService.exception;
 
+import com.After_Buy.DeviceService.client.AdminInternalClient;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -18,12 +20,17 @@ import java.util.stream.Collectors;
  * AdminService의 GlobalExceptionHandler와 동일한 패턴을 사용합니다.
  *
  * @since : 2026.04.06
- * @version : 1.0.0
+ * @version : 1.0.1
  * @author : 최준혁
+ * @author : 신태훈 (2026.04.26 — handleException AdminInternalClient 연동 추가)
  */
 @Slf4j
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class GlobalExceptionHandler {
+
+	private final AdminInternalClient adminInternalClient;
+
 
 	/**
 	 * 커스텀 도메인 특화 비즈니스 예외 핸들링
@@ -85,14 +92,20 @@ public class GlobalExceptionHandler {
 	/**
 	 * 알 수 없는 서버 내부 예외 핸들링 (최종 디펜스 라인)
 	 * 예상치 못한 500급 예외를 처리합니다. 내부 구조 노출을 막고 500 응답으로 변환합니다.
+	 * Admin Service로 비동기 에러 로그를 전송합니다. (Fire & Forget)
 	 *
 	 * @param e       컨트롤러 통제 밖까지 도달한 예외
 	 * @param request 현재 HTTP 요청 (path 추출용)
 	 * @return 500 INTERNAL SERVER ERROR 응답
+	 * @since : 2026.04.26
+	 * @author : 신태훈
 	 */
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<ErrorResponse> handleException(Exception e, HttpServletRequest request) {
 		log.error("[UnhandledException] path={}, message={}", request.getRequestURI(), e.getMessage(), e);
+
+		/* Admin Service로 에러 로그 비동기 전송 (Fire & Forget, 4xx 제외 500급만) */
+		adminInternalClient.sendErrorLogAsync(request.getRequestURI(), e);
 
 		ErrorResponse errorResponse = ErrorResponse.of(
 				ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus().value(),

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -61,3 +61,7 @@ vertex:
 aws:
   lambda:
     function-url: ${AWS_LAMBDA_FUNCTION_URL}
+
+# 타 마이크로서비스 호출 URL (WebClient)
+services:
+  admin-url: ${SERVICES_ADMIN_URL:http://localhost:8084}


### PR DESCRIPTION
## 📌 개요
사용자의 기기 등록, 수정, 삭제 등의 비즈니스 로직 수행 중 발생하는 시스템 에러를 즉각적으로 모니터링하기 위해 중앙 에러 파이프라인 클라이언트를 적용했습니다.

## 🛠️ 작업 내용
- **클라이언트 연동**: Admin Service 내부 통신을 위한 `AdminInternalClient` 클래스 추가
- **예외 처리기 업데이트**: `GlobalExceptionHandler`에 시스템 크래시 감지 시 에러를 비동기로 자동 전송하는 로직 구현
- **보안 및 환경 설정**: `application.yaml`에 `X-Internal-Secret` 인증 통신을 위한 시크릿 키 및 라우팅 경로 설정 추가

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수했나요?
- [x] 테스트를 완료했나요?
- [x] 불필요한 주석을 제거했나요?