### PR TITLE
[FIX] Nginx 매칭 이슈 해결을 위한 API 경로 변경

### DIFF
--- a/src/main/java/com/After_Buy/DeviceService/controller/DeviceController.java
+++ b/src/main/java/com/After_Buy/DeviceService/controller/DeviceController.java
@@ -80,7 +80,7 @@ public class DeviceController {
 	 *                                                               (404)
 	 */
 	@Operation(summary = "기기 등록", description = "새 기기를 등록합니다. warranty_expiry_date는 서버에서 자동 계산됩니다.")
-	@PostMapping
+	@PostMapping("/register")
 	public ResponseEntity<ApiResponse<DeviceResponse>> registerDevice(
 			@AuthenticationPrincipal UserPrincipal userPrincipal,
 			@Valid @RequestBody DeviceRegisterRequest request) {
@@ -121,7 +121,7 @@ public class DeviceController {
 	 * @author : 최준혁
 	 */
 	@Operation(summary = "미분류 기기 목록 조회", description = "폴더에 속하지 않은 미분류 기기 목록을 정렬 조건에 따라 조회합니다.")
-	@GetMapping
+	@GetMapping("/home")
 	public ResponseEntity<ApiResponse<DeviceListResponse>> getDeviceList(
 			@AuthenticationPrincipal UserPrincipal userPrincipal,
 			@RequestParam(value = "sort", defaultValue = "created_desc") String sort) {


### PR DESCRIPTION
## 📌 개요
#### Nginx 매칭 시 api/devices 같은 api를 호출할 때 후행 슬래시 부재로 미인식 문제



## 🛠️ 작업 내용
* GET api/devices -> GET api/devices/home
* POST api/devices -> POST api/devices/register



## ✅ 체크리스트
- [X] 코드 컨벤션을 준수했나요?
- [X] 테스트를 완료했나요?
- [X] 불필요한 주석을 제거했나요?