### PR TITLE
[REFACTOR] warrantyExpiryDate 변수 NPE 에러 방지 코드 추가

### DIFF
--- a/src/main/java/com/After_Buy/DeviceService/service/DeviceService.java
+++ b/src/main/java/com/After_Buy/DeviceService/service/DeviceService.java
@@ -149,14 +149,15 @@ public class DeviceService {
 	 * @return HomeDeviceDto 객체
 	 */
 	private HomeDeviceDto mapToHomeDeviceDto(Device device, boolean isRecent) {
-		long remainingDays = ChronoUnit.DAYS.between(LocalDate.now(), device.getWarrantyExpiryDate());
+		LocalDate expiryDate = device.getWarrantyExpiryDate();
+		Long remainingDays = (expiryDate != null) ? ChronoUnit.DAYS.between(LocalDate.now(), expiryDate) : null;
 
 		HomeDeviceDto.HomeDeviceDtoBuilder builder = HomeDeviceDto.builder()
 				.device_id(device.getDeviceId())
 				.product_name(device.getProductName())
 				.brand(device.getBrand())
 				.image_url(device.getImageUrl())
-				.warranty_expiry_date(device.getWarrantyExpiryDate())
+				.warranty_expiry_date(expiryDate)
 				.days_remaining(remainingDays);
 
 		if (isRecent) {


### PR DESCRIPTION
## 📌 개요
홈 화면 기기 요약 조회 시 발생할 수 있는 보증 기간 만료일(warrantyExpiryDate) 관련 잠재적 NPE를 방어했습니다.

## 🛠️ 작업 내용
- `DeviceService.mapToHomeDeviceDto()` 내부에서 보증 기간 만료일이 `null`일 경우를 대비해, 안전하게 잔여 일수 계산을 스킵하도록 예외 방어 코드를 추가했습니다.

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수했나요?
- [x] 테스트를 완료했나요?
- [x] 불필요한 주석을 제거했나요?
