### PR TITLE
[FIX] 네이버 검색 시 모델명 매칭 방식 수정

### DIFF
--- a/src/main/java/com/After_Buy/DeviceService/service/GeminiParsingService.java
+++ b/src/main/java/com/After_Buy/DeviceService/service/GeminiParsingService.java
@@ -14,7 +14,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
-
 /**
  * Gemini API 연동을 통한 네이버 쇼핑 결과 정제 서비스
  * 네이버 쇼핑 API 원본 응답(제품명, 브랜드)을 Gemini LLM에게 전달하여
@@ -44,7 +43,6 @@ public class GeminiParsingService {
         this.apiKey = apiKey;
         this.objectMapper = new ObjectMapper();
     }
-
 
     /**
      * 네이버 쇼핑 검색 결과 제품명·브랜드 정제 메서드
@@ -108,6 +106,53 @@ public class GeminiParsingService {
     }
 
     /**
+     * 모델명 매핑 일치 여부 판단 메서드
+     * 사용자가 입력한 모델명과 네이버 쇼핑 검색 결과 제목을 Gemini에게 전달하여 같은 제품인지 여부를 판단합니다.
+     *
+     * @param inputModel : 사용자가 입력한 모델명 (예: 16Z90TP-KD7WK)
+     * @param naverTitle : 네이버 쇼핑 검색 결과 제품 제목 (HTML 태그 제거 후)
+     * @return : 동일 제품으로 판단되면 true, 아니면 false
+     * @since : 2026.05.11
+     * @version : 0.0.1
+     * @author : 최준혁
+     */
+    public boolean matchModelName(String inputModel, String naverTitle) {
+        try {
+            String userPrompt = buildModelMatchUserPrompt(inputModel, naverTitle);
+            String requestBody = buildModelMatchRequestBody(userPrompt);
+
+            String responseBody = webClient.post()
+                    .uri(uriBuilder -> uriBuilder
+                            .path(VERTEX_GEMINI_PATH)
+                            .queryParam("key", apiKey)
+                            .build())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(requestBody)
+                    .retrieve()
+                    .onStatus(
+                            status -> status.is4xxClientError() || status.is5xxServerError(),
+                            clientResponse -> clientResponse.bodyToMono(String.class)
+                                    .doOnNext(errorBody -> log.error(
+                                            "[GeminiParsingService] 모델명 매핑 Gemini API 오류 (HTTP {}): {}",
+                                            clientResponse.statusCode().value(), errorBody))
+                                    .flatMap(errorBody -> reactor.core.publisher.Mono.error(
+                                            new RuntimeException("Gemini HTTP 오류 " + clientResponse.statusCode().value()
+                                                    + ": " + errorBody))))
+                    .bodyToMono(String.class)
+                    .block();
+
+            return parseModelMatchResponse(responseBody, inputModel, naverTitle);
+
+        } catch (Exception e) {
+            /* Gemini 호출 실패 시 기존 normalizeString contains 로직으로 폴백 */
+            log.warn("[GeminiParsingService] 모델명 매핑 Gemini 호출 실패, 폴백 로직 사용. 사유: {}", e.getMessage());
+            String normalizedTitle = naverTitle.replaceAll("[\\s\\-_]", "").toUpperCase();
+            String normalizedModel = inputModel.replaceAll("[\\s\\-_]", "").toUpperCase();
+            return normalizedTitle.contains(normalizedModel);
+        }
+    }
+
+    /**
      * 시스템 인스트럭션 생성 메서드 (Gemini 역할/규칙 모듈)
      * 프롬프트에서 분리하여 토큰 절감. 각 호출마다 반복 전송하지 않고 요청 구조에서 도구 역할을 담습니다.
      * 전자기기 판별 기준과 정제 규칙을 포함합니다.
@@ -118,14 +163,137 @@ public class GeminiParsingService {
      */
     private String buildSystemInstruction() {
         return "You are a Korean e-commerce product classifier. " +
-               "Given a product name and brand from Naver Shopping:\n" +
-               "1. Determine if it is a consumer ELECTRONICS DEVICE " +
-               "(smartphone, laptop, tablet, earphones, headphones, smartwatch, TV, monitor, camera, game console). " +
-               "NOT a case, film, charger, cable, stand, bag, or accessory.\n" +
-               "2. If NOT a device: output {\"product_name\":null,\"brand\":null}\n" +
-               "3. If a device: remove model codes (e.g. SM-S928N, MKGP3KH/A), " +
-               "remove storage capacity (256GB, 512GB, 1TB etc), remove sales words (정품/자급제/공식), " +
-               "remove brand prefix duplication, normalize brand (삼성전자→삼성, LG전자→LG).";
+                "Given a product name and brand from Naver Shopping:\n" +
+                "1. Determine if it is a consumer ELECTRONICS DEVICE " +
+                "(smartphone, laptop, tablet, earphones, headphones, smartwatch, TV, monitor, camera, game console). " +
+                "NOT a case, film, charger, cable, stand, bag, or accessory.\n" +
+                "2. If NOT a device: output {\"product_name\":null,\"brand\":null}\n" +
+                "3. If a device: remove model codes (e.g. SM-S928N, MKGP3KH/A), " +
+                "remove storage capacity (256GB, 512GB, 1TB etc), remove sales words (정품/자급제/공식), " +
+                "remove brand prefix duplication, normalize brand (삼성전자→삼성, LG전자→LG).";
+    }
+
+    /**
+     * 모델명 매핑 전용 시스템 인스트럭션 생성 메서드
+     * 가전 모델명 도메인 지식(접미사 규칙, 체급/사양 구분 기준)을 포함한 고도화 프롬프트입니다.
+     *
+     * @return : 모델명 매핑 판단용 Gemini system_instruction 텍스트
+     * @since : 2026.05.11
+     * @version : 0.0.1
+     * @author : 최준혁
+     */
+    private String buildModelMatchSystemInstruction() {
+        return "You are an expert in consumer electronics model naming conventions, " +
+                "specializing in Korean market products.\n\n" +
+                "## Your Task\n" +
+                "Determine whether a user-provided model name refers to the SAME product " +
+                "as a product title from Naver Shopping search results.\n\n" +
+                "## Domain Knowledge: Model Name Structure\n" +
+                "Consumer electronics model names (laptops, smartphones, TVs, etc.) follow:\n" +
+                "  [Base Model]-[Spec Code][Regional/Color Suffix]\n\n" +
+                "### Suffixes to IGNORE (do NOT use as grounds for mismatch):\n" +
+                "  - Color or distribution-channel codes: WK, AK, AR, BK, W, K, A, etc.\n" +
+                "  - These appear at the END, AFTER the core spec code.\n" +
+                "  - Example: KD7WK → core spec is KD7, WK is a suffix → SAME product as KD7.\n" +
+                "  - Example: 16Z90TP-KD7WK vs 16Z90TP-KD7 → is_match: true\n\n" +
+                "### Must DISTINGUISH (return false if these differ):\n" +
+                "  - Product tier / screen size indicator: 16Z vs 17Z (different product line).\n" +
+                "  - Spec grade code (CPU/hardware tier): KD7 vs KD5, KD3 vs KD7 (different spec).\n" +
+                "  - Generation indicator that affects internal hardware.\n\n" +
+                "## Matching Algorithm:\n" +
+                "1. Extract the core model number from the user input by stripping trailing alphabetic suffixes.\n" +
+                "2. Normalize both strings: remove hyphens, spaces, underscores. Compare case-insensitively.\n" +
+                "3. Check if the Naver title CONTAINS the normalized core model number.\n" +
+                "4. If yes AND no spec-grade/tier mismatch exists → is_match: true.\n" +
+                "5. If the core numbers differ (different tier or spec grade) → is_match: false.\n\n" +
+                "## Output Format (strict JSON, no other text):\n" +
+                "{\"is_match\": true_or_false, \"reason\": \"Korean explanation\", " +
+                "\"refined_model_name\": \"core model name without regional suffix\"}";
+    }
+
+    /**
+     * 모델명 매핑 전용 유저 프롬프트 생성 메서드
+     *
+     * @param inputModel : 사용자 입력 모델명
+     * @param naverTitle : 네이버 검색 결과 제품명 (HTML 태그 제거 후)
+     * @return : 비교 데이터만 담은 최소 유저 프롬프트
+     * @since : 2026.05.11
+     * @version : 0.0.1
+     * @author : 최준혁
+     */
+    private String buildModelMatchUserPrompt(String inputModel, String naverTitle) {
+        return "User input model: " + inputModel + "\nNaver result title: " + naverTitle;
+    }
+
+    /**
+     * 모델명 매핑 전용 Gemini REST API 요청 본문(JSON) 생성 메서드
+     *
+     * @param userPrompt : 비교 데이터만 담은 유저 프롬프트
+     * @return : Gemini API 요청 JSON 문자열
+     * @since : 2026.05.11
+     * @version : 0.0.1
+     * @author : 최준혁
+     */
+    private String buildModelMatchRequestBody(String userPrompt) {
+        try {
+            Map<String, Object> requestMap = Map.of(
+                    "system_instruction", Map.of(
+                            "role", "system",
+                            "parts", List.of(Map.of("text", buildModelMatchSystemInstruction()))),
+                    "contents", List.of(
+                            Map.of(
+                                    "role", "user",
+                                    "parts", List.of(Map.of("text", userPrompt)))),
+                    "generationConfig", Map.of(
+                            "response_mime_type", "application/json"));
+            return objectMapper.writeValueAsString(requestMap);
+        } catch (Exception e) {
+            throw new RuntimeException("Gemini 모델명 매핑 요청 본문 생성 실패", e);
+        }
+    }
+
+    /**
+     * 모델명 매핑 Gemini 응답 파싱 메서드
+     * candidates[0].content.parts[0].text 에서 JSON을 추출하여 is_match 값을 반환합니다.
+     * 파싱 실패 시 false를 반환하여 안전하게 검색 거부를 유도합니다.
+     *
+     * @param responseBody : Gemini API 원본 응답 JSON 문자열
+     * @param inputModel   : 로깅용 원본 입력 모델명
+     * @param naverTitle   : 로깅용 네이버 검색 결과 제목
+     * @return : Gemini가 동일 제품으로 판단하면 true, 아니면 false
+     * @since : 2026.05.11
+     * @version : 0.0.1
+     * @author : 최준혁
+     */
+    private boolean parseModelMatchResponse(String responseBody, String inputModel, String naverTitle) {
+        try {
+            JsonNode root = objectMapper.readTree(responseBody);
+            String text = root
+                    .path("candidates").get(0)
+                    .path("content")
+                    .path("parts").get(0)
+                    .path("text")
+                    .asText();
+
+            String cleanedText = text.trim();
+            if (cleanedText.startsWith("```")) {
+                cleanedText = cleanedText.replaceAll("```[a-z]*\\n?", "").replace("```", "").trim();
+            }
+
+            JsonNode parsedResult = objectMapper.readTree(cleanedText);
+            boolean isMatch = parsedResult.path("is_match").asBoolean(false);
+            String reason = parsedResult.path("reason").asText("");
+            String refinedModelName = parsedResult.path("refined_model_name").asText(inputModel);
+
+            log.info("[GeminiParsingService] 모델명 매핑 결과 - 입력: '{}', 네이버: '{}', 일치: {}, 정제명: '{}', 사유: {}",
+                    inputModel, naverTitle, isMatch, refinedModelName, reason);
+
+            return isMatch;
+
+        } catch (Exception e) {
+            log.warn("[GeminiParsingService] 모델명 매핑 응답 파싱 실패, false 반환. 사유: {}", e.getMessage());
+            return false;
+        }
     }
 
     /**
@@ -165,13 +333,10 @@ public class GeminiParsingService {
                     "contents", List.of(
                             Map.of(
                                     "role", "user",
-                                    "parts", List.of(Map.of("text", userPrompt))
-                            )
-                    ),
+                                    "parts", List.of(Map.of("text", userPrompt)))),
                     /* JSON 응답 강제: 프롬프트에 'JSON으로 답해줘' 구문 보담 안해도 됨 */
                     "generationConfig", Map.of(
-                            "response_mime_type", "application/json")
-            );
+                            "response_mime_type", "application/json"));
             return objectMapper.writeValueAsString(requestMap);
         } catch (Exception e) {
             throw new RuntimeException("Gemini 요청 본문 생성 실패", e);

--- a/src/main/java/com/After_Buy/DeviceService/service/NaverSearchService.java
+++ b/src/main/java/com/After_Buy/DeviceService/service/NaverSearchService.java
@@ -58,7 +58,7 @@ public class NaverSearchService {
                 .uri(uriBuilder -> uriBuilder
                         .path("/shop.json")
                         .queryParam("query", modelName)
-                        .queryParam("display", 1)  // 가장 유사도 높은 최상단 데이터 1개만 매핑
+                        .queryParam("display", 1) // 가장 유사도 높은 최상단 데이터 1개만 매핑
                         .queryParam("sort", "sim") // 유사도(정확도) 순 정렬 명시
                         .build())
                 .header("X-Naver-Client-Id", clientId)
@@ -77,9 +77,10 @@ public class NaverSearchService {
         // 네이버 API 응답의 title 등에 포함된 <b>, </b> 태그 등을 이스케이프 해제 및 정제
         String cleanTitle = cleanHtmlTags(item.getTitle());
 
-        // 검색된 제품의 이름(cleanTitle)에 사용자가 입력한 모델명이 포함되어 있는지 엄격하게 검증 (띄어쓰기, 하이픈 무시)
-        if (!normalizeString(cleanTitle).contains(normalizeString(modelName))) {
-            log.warn("[NaverSearchService] 검색 결과가 요청한 모델명과 일치하지 않습니다. 매핑 거부. (조회된 상품: {}, 요청 모델명: {})", cleanTitle, modelName);
+        // Gemini를 통한 유연한 모델명 매핑 검증
+        // 단순 contains 대신 가전 도메인 지식을 보유한 Gemini가 판단 (접미사 WK, AK 등 무시)
+        if (!geminiParsingService.matchModelName(modelName, cleanTitle)) {
+            log.warn("[NaverSearchService] Gemini 모델명 매핑 불일치. 검색 거부. (네이버 결과: {}, 요청 모델명: {})", cleanTitle, modelName);
             throw new CustomException(ErrorCode.SEARCH_NO_RESULT);
         }
 
@@ -125,7 +126,8 @@ public class NaverSearchService {
      * @author : 최준혁
      */
     private String normalizeString(String input) {
-        if (input == null) return "";
+        if (input == null)
+            return "";
         return input.replaceAll("[\\s\\-_]", "").toUpperCase();
     }
 
@@ -140,7 +142,8 @@ public class NaverSearchService {
      * @author : 최준혁
      */
     private String cleanHtmlTags(String input) {
-        if (input == null) return null;
+        if (input == null)
+            return null;
         String unescaped = HtmlUtils.htmlUnescape(input);
         return unescaped.replaceAll("<[^>]*>", "");
     }


### PR DESCRIPTION
## 📌 개요
#### 네이버 검색 결과 시 모델명과 매칭이된 결과가 응답되지 않는 문제 수정

* 제미나이 파싱 시 모델명과 완전히 일치하지 않는 결과에 대해 응답을 하지 않는 로직 발견


## 🛠️ 작업 내용

* 기존 : 16Z90TP-KD7WK에서 WK(색상, 국가코드) 포함 시 모델명 완전 일치 방식에 의해 응답이 거부됨

* 수정 : 제미나이 정제 시 사용자의 의도에 맞는 결과인지 파악 (색상, 국가 코드 등의 불필요 모델명 부분 미포함 파싱 및 전자기기 여부 파악)


## ✅ 체크리스트
- [X] 코드 컨벤션을 준수했나요?
- [X] 테스트를 완료했나요?
- [X] 불필요한 주석을 제거했나요?