### PR TITLE
[FIX] ocr-stat api 응답 양식 변경

### DIFF
--- a/src/main/java/com/After_Buy/DeviceService/dto/response/DailyOcrResultTrendDto.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/response/DailyOcrResultTrendDto.java
@@ -1,0 +1,32 @@
+package com.After_Buy.DeviceService.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 통계용 일간 OCR 결과 트렌드 DTO
+ *
+ * @since : 2026.05.23
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@Builder
+public class DailyOcrResultTrendDto {
+
+	@JsonProperty("date")
+	private String date;
+
+	@JsonProperty("total_attempts")
+	private Long totalAttempts;
+
+	@JsonProperty("success_count")
+	private Long successCount;
+
+	@JsonProperty("modified_count")
+	private Long modifiedCount;
+
+	@JsonProperty("failure_count")
+	private Long failureCount;
+}

--- a/src/main/java/com/After_Buy/DeviceService/dto/response/FieldFailureStatDto.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/response/FieldFailureStatDto.java
@@ -1,0 +1,23 @@
+package com.After_Buy.DeviceService.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 통계용 항목별 OCR 실패 현황 DTO
+ *
+ * @since : 2026.05.23
+ * @version : 1.0.0
+ * @author : 최준혁
+ */
+@Getter
+@Builder
+public class FieldFailureStatDto {
+
+	@JsonProperty("field_name")
+	private String fieldName;
+
+	@JsonProperty("failure_count")
+	private Long failureCount;
+}

--- a/src/main/java/com/After_Buy/DeviceService/dto/response/OcrStatsResponse.java
+++ b/src/main/java/com/After_Buy/DeviceService/dto/response/OcrStatsResponse.java
@@ -29,6 +29,12 @@ public class OcrStatsResponse {
     @JsonProperty("field_modified_stats")
     private List<FieldModifiedStatDto> fieldModifiedStats;
 
+    @JsonProperty("field_failure_stats")
+    private List<FieldFailureStatDto> fieldFailureStats;
+
     @JsonProperty("daily_failure_trend")
     private List<DailyFailureTrendDto> dailyFailureTrend;
+
+    @JsonProperty("daily_result_trend")
+    private List<DailyOcrResultTrendDto> dailyResultTrend;
 }

--- a/src/main/java/com/After_Buy/DeviceService/repository/OcrLogRepository.java
+++ b/src/main/java/com/After_Buy/DeviceService/repository/OcrLogRepository.java
@@ -48,4 +48,28 @@ public interface OcrLogRepository extends JpaRepository<OcrLog, Long> {
                    "GROUP BY DATE(o.created_at) " +
                    "ORDER BY date", nativeQuery = true)
     java.util.List<Object[]> findDailyFailureTrendRaw(@Param("start") java.time.LocalDateTime start, @Param("end") java.time.LocalDateTime end);
+
+    /**
+     * 특정 기간 내의 일별 OCR 결과 집계
+     */
+    @Query(value = "SELECT DATE(o.created_at) as date, " +
+                   "COUNT(*) as totalAttempts, " +
+                   "SUM(CASE WHEN o.is_success = true THEN 1 ELSE 0 END) as successCount, " +
+                   "SUM(CASE WHEN o.modified_fields IS NOT NULL AND JSON_LENGTH(o.modified_fields) > 0 THEN 1 ELSE 0 END) as modifiedCount, " +
+                   "SUM(CASE WHEN o.is_success = false THEN 1 ELSE 0 END) as failureCount " +
+                   "FROM ocr_logs o " +
+                   "WHERE o.created_at >= :start AND o.created_at <= :end " +
+                   "GROUP BY DATE(o.created_at) " +
+                   "ORDER BY date", nativeQuery = true)
+    java.util.List<Object[]> findDailyOcrResultTrendRaw(@Param("start") java.time.LocalDateTime start, @Param("end") java.time.LocalDateTime end);
+
+    /**
+     * 특정 기간 내의 OCR 유형별 실패 횟수 집계
+     */
+    @Query(value = "SELECT o.ocr_type as fieldName, COUNT(*) as failureCount " +
+                   "FROM ocr_logs o " +
+                   "WHERE o.is_success = false AND o.created_at >= :start AND o.created_at <= :end " +
+                   "GROUP BY o.ocr_type " +
+                   "ORDER BY failureCount DESC", nativeQuery = true)
+    java.util.List<Object[]> findFieldFailureStatsRaw(@Param("start") java.time.LocalDateTime start, @Param("end") java.time.LocalDateTime end);
 }

--- a/src/main/java/com/After_Buy/DeviceService/service/InternalDeviceService.java
+++ b/src/main/java/com/After_Buy/DeviceService/service/InternalDeviceService.java
@@ -25,7 +25,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.After_Buy.DeviceService.dto.response.OcrStatsResponse;
 import com.After_Buy.DeviceService.dto.response.FieldModifiedStatDto;
+import com.After_Buy.DeviceService.dto.response.FieldFailureStatDto;
 import com.After_Buy.DeviceService.dto.response.DailyFailureTrendDto;
+import com.After_Buy.DeviceService.dto.response.DailyOcrResultTrendDto;
 
 /**
  * 인프라 및 서비스 간 내부 통신용 서비스
@@ -158,12 +160,44 @@ public class InternalDeviceService {
                                         .build();
                 }).collect(Collectors.toList());
 
+                // 4. daily_result_trend 도출: 프론트에서 날짜별 성공률을 계산할 수 있도록 날짜별 전체/성공/오인식/실패를 함께 반환
+                List<Object[]> rawResultTrend = ocrLogRepository.findDailyOcrResultTrendRaw(startDateTime, endDateTime);
+                List<DailyOcrResultTrendDto> dailyResultTrend = rawResultTrend.stream().map(row -> {
+                        String dateStr = row[0].toString();
+                        Long totalCnt = ((Number) row[1]).longValue();
+                        Long successCnt = ((Number) row[2]).longValue();
+                        Long modifiedCnt = ((Number) row[3]).longValue();
+                        Long failureCnt = ((Number) row[4]).longValue();
+
+                        return DailyOcrResultTrendDto.builder()
+                                        .date(dateStr)
+                                        .totalAttempts(totalCnt)
+                                        .successCount(successCnt)
+                                        .modifiedCount(modifiedCnt)
+                                        .failureCount(failureCnt)
+                                        .build();
+                }).collect(Collectors.toList());
+
+                // 5. field_failure_stats 도출: 현재 스키마상 실패 항목은 OCR 유형(MODEL/SERIAL/RECEIPT) 기준으로 집계
+                List<Object[]> rawFieldFailures = ocrLogRepository.findFieldFailureStatsRaw(startDateTime, endDateTime);
+                List<FieldFailureStatDto> fieldFailureStats = rawFieldFailures.stream().map(row -> {
+                        String fieldName = row[0].toString();
+                        Long failCnt = ((Number) row[1]).longValue();
+
+                        return FieldFailureStatDto.builder()
+                                        .fieldName(fieldName)
+                                        .failureCount(failCnt)
+                                        .build();
+                }).collect(Collectors.toList());
+
                 return OcrStatsResponse.builder()
                                 .totalAttempts(totalAttempts)
                                 .failureCount(failureCount)
                                 .modifiedCount(modifiedCount)
                                 .fieldModifiedStats(fieldStats)
+                                .fieldFailureStats(fieldFailureStats)
                                 .dailyFailureTrend(dailyTrend)
+                                .dailyResultTrend(dailyResultTrend)
                                 .build();
         }
 }


### PR DESCRIPTION
## 📌 개요
#### 날짜별 OCR 성공율과 항목별 오인식 / 실패 건수 집계를 위한 API 응답 재정의



## 🛠️ 작업 내용
1. 날짜별 성공률 집계 및 반환
2. 항목별 실패 건수 반환



## ✅ 체크리스트
- [X] 코드 컨벤션을 준수했나요?
- [X] 테스트를 완료했나요?
- [X] 불필요한 주석을 제거했나요?