### PR TITLE
fix: Device JWT 만료 토큰 응답 처리

### DIFF
--- a/src/main/java/com/After_Buy/DeviceService/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/After_Buy/DeviceService/security/JwtAuthenticationFilter.java
@@ -31,6 +31,15 @@ import java.util.List;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 	private final JwtTokenProvider jwtTokenProvider;
+	private static final String TOKEN_EXPIRED_RESPONSE = """
+			{
+			  "success": false,
+			  "error": {
+			    "code": "TOKEN_EXPIRED",
+			    "message": "Access Token이 만료되었거나 유효하지 않습니다."
+			  }
+			}
+			""";
 
 	/**
 	 * 필터 체인 내부 검증 로직 구현부
@@ -47,7 +56,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
 			throws ServletException, IOException {
 		String token = extractToken(request);
-		if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+		if (StringUtils.hasText(token)) {
+			if (!jwtTokenProvider.validateToken(token)) {
+				if (isPublicPath(request)) {
+					filterChain.doFilter(request, response);
+					return;
+				}
+				SecurityContextHolder.clearContext();
+				response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+				response.setContentType("application/json;charset=UTF-8");
+				response.getWriter().write(TOKEN_EXPIRED_RESPONSE);
+				return;
+			}
 			try {
 				Long userId = jwtTokenProvider.getUserIdFromToken(token);
 				UserPrincipal userPrincipal = new UserPrincipal(userId);
@@ -60,6 +80,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			}
 		}
 		filterChain.doFilter(request, response);
+	}
+
+	private boolean isPublicPath(HttpServletRequest request) {
+		String path = request.getRequestURI();
+		return path.startsWith("/internal/")
+				|| path.equals("/actuator/health")
+				|| path.equals("/swagger-ui.html")
+				|| path.startsWith("/swagger-ui/")
+				|| path.startsWith("/v3/api-docs/")
+				|| path.equals("/api/devices/swagger-ui.html")
+				|| path.startsWith("/api/devices/swagger-ui/")
+				|| path.startsWith("/api/devices/v3/api-docs/");
 	}
 
 	/**


### PR DESCRIPTION
## 📌 개요

Device Service의 JWT 인증 필터에서 만료/무효 Access Token 요청을 명확히 처리하도록 수정했습니다.

기존에는 만료된 Access Token이 들어와도 필터 단계에서 에러 응답을 반환하지 않고 요청을 다음 단계로 넘겨, 프론트엔드가 토큰 만료 상태를 안정적으로 감지하기 어려웠습니다.

이번 수정으로 보호 API에서는 `401 TOKEN_EXPIRED`를 반환하고, internal, health, Swagger 경로는 필터 차단 대상에서 제외했습니다.

## 🛠️ 작업 내용

- 만료/무효 Access Token 요청 시 보호 API에서 `401 TOKEN_EXPIRED` 반환
- `/internal/**`, `/actuator/health`, Swagger 경로는 public path로 예외 처리
- Access Token 만료 시 프론트 refresh 트리거가 가능하도록 응답 정책 정리

## ✅ 체크리스트

- [x] 코드 컨벤션을 준수했나요?
- [x] 컴파일 검증을 완료했나요?
- [x] 불필요한 주석을 제거했나요?

## 🧪 테스트

- `./gradlew.bat compileJava` 성공

## ⚠️ 참고 사항

- Auth Service의 refresh API와 연동되어, Device 보호 API에서 `401 TOKEN_EXPIRED` 수신 시 프론트가 토큰 재발급을 시도할 수 있습니다.